### PR TITLE
Support NSX cert/key/ca

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -625,10 +625,24 @@ data:
     [operator]
 
     # The default certificate for HTTPS load balancing.
-    # Must be specified along with lb_priv_key option.
+    # Must be base64 encoded and specified along with lb_priv_key option.
     # Operator will create lb-secret for NCP based on these two options.
     #lb_default_cert = <None>
 
     # The private key for default certificate for HTTPS load balancing.
-    # Must be specified along with lb_default_cert option.
+    # Must be base64 encoded and specified along with lb_default_cert option.
     #lb_priv_key = <None>
+
+    # The certificate for NSX connection.
+    # Must be base64 encoded and specified along with nsx_api_private_key.
+    # Operator will create nsx-secret for NCP based on these two options.
+    #nsx_api_cert = <None>
+
+    # The private key for NSX certificate.
+    # Must be base64 encoded and specified along with nsx_api_cert.
+    #nsx_api_private_key = <None>
+
+    # The CA to use in verifying the NSX Manager server certificate.
+    # The content should be base64 encoded and will be ignored if "insecure" is
+    # set to True.
+    # nsx_ca = <None>

--- a/manifest/cluster-network-15-nsx-secret.yaml
+++ b/manifest/cluster-network-15-nsx-secret.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-data: {tls.crt: null, tls.key: null}
+data: {tls.crt: "{{.NsxCert}}", tls.key: "{{.NsxKey}}", tls.ca: "{{.NsxCA}}"}
 kind: Secret
 metadata: {name: nsx-secret, namespace: nsx-system}
 type: kubernetes.io/tls

--- a/manifest/cluster-network-19-nsx-ncp.yaml
+++ b/manifest/cluster-network-19-nsx-ncp.yaml
@@ -53,3 +53,9 @@ spec:
               - {key: tls.crt, path: lb-cert/tls.crt}
               - {key: tls.key, path: lb-cert/tls.key}
               name: lb-secret
+          - secret:
+              items:
+              - {key: tls.crt, path: nsx-cert/tls.crt}
+              - {key: tls.key, path: nsx-cert/tls.key}
+              - {key: tls.ca, path: nsx-cert/tls.ca}
+              name: nsx-secret

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -1,6 +1,3 @@
-/* Copyright © 2020 VMware, Inc. All Rights Reserved.
-   SPDX-License-Identifier: Apache-2.0 */
-
 package configmap
 
 import (
@@ -196,6 +193,19 @@ func Render(configmap *corev1.ConfigMap) ([]*unstructured.Unstructured, error) {
 	}
 	renderData.Data[ncptypes.LbCertRenderKey] = lbCert
 	renderData.Data[ncptypes.LbKeyRenderKey] = lbKey
+
+	// Set NSX secret
+	nsxCert := ""
+	nsxKey := ""
+	nsxCA := ""
+	if err == nil && sec.HasKey("nsx_api_cert") && sec.HasKey("nsx_api_private_key") {
+		nsxCert = sec.Key("nsx_api_cert").Value()
+		nsxKey = sec.Key("nsx_api_private_key").Value()
+		nsxCA = sec.Key("nsx_ca").Value()
+	}
+	renderData.Data[ncptypes.NsxCertRenderKey] = nsxCert
+	renderData.Data[ncptypes.NsxKeyRenderKey] = nsxKey
+	renderData.Data[ncptypes.NsxCARenderKey] = nsxCA
 
 	manifests, err := render.RenderDir(manifestDir, &renderData)
 	if err != nil {

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -1,6 +1,3 @@
-/* Copyright © 2020 VMware, Inc. All Rights Reserved.
-   SPDX-License-Identifier: Apache-2.0 */
-
 package types
 
 const (
@@ -21,4 +18,11 @@ const (
 	NetworkType                 string = "ncp"
 	LbCertRenderKey             string = "LbCert"
 	LbKeyRenderKey              string = "LbKey"
+	NsxCertRenderKey            string = "NsxCert"
+	NsxKeyRenderKey             string = "NsxKey"
+	NsxCARenderKey              string = "NsxCA"
+	NsxSecretName               string = "nsx-secret"
+	NsxCertTempPath             string = "/tmp/nsx.cert"
+	NsxKeyTempPath              string = "/tmp/nsx.key"
+	NsxCATempPath               string = "/tmp/nsx.ca"
 )


### PR DESCRIPTION
1. Support the user configure NSX cert/key/ca in operator
configmap yaml file
2. Node controller can connect to NSX manager via NSX cert/key