### PR TITLE
Drop the CIDR removal check in configmap controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ User needs to set NCP image as an environment parameter `NCP_IMAGE` in `deploy/o
 
 ### Unsafe changes
 If CIDRs in `clusterNetwork` are already applied, it is unsafe to remove them.
-NSX NCP operator will fail to reconcile new configurations if it detects some
-existing network CIDRs are deleted.
+NSX NCP operator won't fail when it detects some existing network CIDRs are deleted,
+but the removal may cause unexpected issues.
 
 ## Contributing
 

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -278,43 +278,6 @@ func inSlice(str string, s []string) bool {
 	return false
 }
 
-func ValidateChangeIsSafe(currConfig *corev1.ConfigMap, prevConfig *corev1.ConfigMap) error {
-	if prevConfig == nil {
-		return nil
-	}
-	currCfg, err := ini.Load([]byte(currConfig.Data[ncptypes.ConfigMapDataKey]))
-	if err != nil {
-		log.Error(err, "Failed to load current ConfigMap")
-		return err
-	}
-	prevCfg, err := ini.Load([]byte(prevConfig.Data[ncptypes.ConfigMapDataKey]))
-	if err != nil {
-		log.Error(err, "Failed to load previous ConfigMap")
-		return err
-	}
-	currBlocks := strings.Split(currCfg.Section("nsx_v3").Key("container_ip_blocks").Value(), ",")
-	prevBlocks := strings.Split(prevCfg.Section("nsx_v3").Key("container_ip_blocks").Value(), ",")
-
-	missingBlocks := []string{}
-	for _, p := range prevBlocks {
-		prevExists := false
-		for _, c := range currBlocks {
-			if p == c {
-				prevExists = true
-				break
-			}
-		}
-		if !prevExists {
-			missingBlocks = append(missingBlocks, p)
-		}
-	}
-
-	if len(missingBlocks) > 0 {
-		return errors.Errorf("cluster network %s are missing", missingBlocks)
-	}
-	return nil
-}
-
 func generateConfigMap(srcCfg *ini.File, sections []string) (string, error) {
 	destCfg := ini.Empty()
 	for _, name := range sections {

--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -204,24 +204,6 @@ func TestInSlice(t *testing.T) {
 	assert.True(t, inSlice(str, strs))
 }
 
-func TestValidateChangeIsSafe(t *testing.T) {
-	currConfigMap := createMockConfigMap()
-	var prevConfigMap *corev1.ConfigMap = nil
-	err := ValidateChangeIsSafe(currConfigMap, prevConfigMap)
-	assert.Nil(t, err)
-
-	prevConfigMap = createMockConfigMap()
-	err = ValidateChangeIsSafe(currConfigMap, prevConfigMap)
-	assert.Nil(t, err)
-
-	data := &prevConfigMap.Data
-	cfg, _ := ini.Load([]byte((*data)[ncptypes.ConfigMapDataKey]))
-	cfg.Section("nsx_v3").NewKey("container_ip_blocks", "10.0.0.0/16")
-	(*data)[ncptypes.ConfigMapDataKey], _ = iniWriteToString(cfg)
-	err = ValidateChangeIsSafe(currConfigMap, prevConfigMap)
-	assert.Error(t, err, "cluster network 10.0.0.0/16 are missing")
-}
-
 func TestGenerateConfigMap(t *testing.T) {
 	cfg := ini.Empty()
 	cfg.NewSections("sec1", "sec2", "sec3")

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -197,15 +197,6 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{}, nil
 	}
 
-	// Check if new change is safe to apply
-	err = ValidateChangeIsSafe(instance, appliedConfigMap)
-	if err != nil {
-		log.Error(err, "New configuration is not safe to apply")
-		r.status.SetDegraded(statusmanager.OperatorConfig, "InvalidOperatorConfig",
-			fmt.Sprintf("The operator configuration is not safe to apply: %v", err))
-		return reconcile.Result{}, err
-	}
-
 	// Render configurations
 	objs, err := Render(instance)
 	if err != nil {


### PR DESCRIPTION
In case the user added the wrong CIDR but cannot delete it.