### PR TITLE
Set process_oc_network to False by default

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -40,6 +40,7 @@ func FillDefaults(configmap *corev1.ConfigMap, spec *configv1.NetworkSpec) error
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_v3", "single_tier_topology", "True", true))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "coe", "enable_snat", "True", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "ha", "enable", "True", false))
+	appendErrorIfNotNil(&errs, fillDefault(cfg, "k8s", "process_oc_network", "False", true))
 	appendErrorIfNotNil(&errs, fillClusterNetwork(spec, cfg))
 
 	// Write config back to ConfigMap data

--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -56,6 +56,7 @@ func TestFillDefaults(t *testing.T) {
 	assert.Equal(t, "True", cfg.Section("nsx_v3").Key("single_tier_topology").Value())
 	assert.Equal(t, "True", cfg.Section("coe").Key("enable_snat").Value())
 	assert.Equal(t, "True", cfg.Section("ha").Key("enable").Value())
+	assert.Equal(t, "False", cfg.Section("k8s").Key("process_oc_network").Value())
 	assert.Equal(t, "10.0.0.0/24", cfg.Section("nsx_v3").Key("container_ip_blocks").Value())
 }
 


### PR DESCRIPTION
As the operator takes care of managing the network CRD,
NCP can safely ignore it.