### PR TITLE
Allow DS and NCP deployment multiple recreations

### DIFF
--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -204,11 +204,11 @@ func identifyAndGetInstance(resName string) runtime.Object {
 
 func (r *ReconcilePod) identifyAndGetK8SObjToCreate(resName string) *unstructured.Unstructured {
 	if resName == ncptypes.NsxNcpBootstrapDsName {
-		return r.sharedInfo.NsxNcpBootstrapDsSpec
+		return r.sharedInfo.NsxNcpBootstrapDsSpec.DeepCopy()
 	} else if resName == ncptypes.NsxNodeAgentDsName {
-		return r.sharedInfo.NsxNodeAgentDsSpec
+		return r.sharedInfo.NsxNodeAgentDsSpec.DeepCopy()
 	} else {
-		return r.sharedInfo.NsxNcpDeploymentSpec
+		return r.sharedInfo.NsxNcpDeploymentSpec.DeepCopy()
 	}
 }
 


### PR DESCRIPTION
When any of the DS or NSX-NCP deployment is deleted, its spec from
sharedInfo is consumed to recreate the spec. However, we must not
change the spec in the sharedInfo as it's updated with resourceVersion
field which prohibits further usage of the spec.