### PR TITLE
Ensure service CIDRs are updated in any case

### DIFF
--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -220,6 +220,18 @@ func TestInSlice(t *testing.T) {
 	assert.True(t, inSlice(str, strs))
 }
 
+func TestStringSliceEqual(t *testing.T) {
+	slice1 := []string{"a", "b"}
+    slice2 := []string{"b", "a"}
+    assert.True(t, stringSliceEqual(slice1, slice2))
+    slice1 = []string{"b", "c"}
+    assert.False(t, stringSliceEqual(slice1, slice2))
+    slice1 = []string{"x", "y"}
+    assert.False(t, stringSliceEqual(slice1, slice2))
+    slice2 = []string{"x", "y"}
+    assert.True(t, stringSliceEqual(slice1, slice2))
+}
+
 func TestGenerateConfigMap(t *testing.T) {
 	cfg := ini.Empty()
 	cfg.NewSections("sec1", "sec2", "sec3")


### PR DESCRIPTION
As NCP does not handle service CIDRs, if these are the only
item being updated on the network CR, NCP skips procesing
the resource status update.

This patch ensures the network CR is updated if necessary
even if the operator is not applying any change to NCP.