### PR TITLE
Retrieve nsx-secret to generate applied operator configmap

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -368,8 +368,14 @@ func generateConfigMap(srcCfg *ini.File, sections []string) (string, error) {
 	return iniWriteToString(destCfg)
 }
 
+func FillKeyIfPresent(opCfg *ini.File, sec string, key string, data []byte) {
+	if len(data) > 0 {
+		opCfg.Section(sec).NewKey(key, b64.StdEncoding.EncodeToString(data))
+	}
+}
+
 func GenerateOperatorConfigMap(opConfigmap *corev1.ConfigMap, ncpConfigMap *corev1.ConfigMap,
-	agentConfigMap *corev1.ConfigMap, lbSecret *corev1.Secret) error {
+	agentConfigMap *corev1.ConfigMap, lbSecret *corev1.Secret, nsxSecret *corev1.Secret) error {
 	ncpCfg, err := ini.Load([]byte(ncpConfigMap.Data[operatortypes.ConfigMapDataKey]))
 	if err != nil {
 		log.Error(err, "Failed to load nsx-ncp ConfigMap")
@@ -396,10 +402,15 @@ func GenerateOperatorConfigMap(opConfigmap *corev1.ConfigMap, ncpConfigMap *core
 			opCfg.Section(name).NewKey(key, sec.Key(key).Value())
 		}
 	}
+	opCfg.NewSection("operator")
 	if lbSecret != nil {
-		opCfg.NewSection("operator")
-		opCfg.Section("operator").NewKey("lb_default_cert", b64.StdEncoding.EncodeToString(lbSecret.Data["tls.crt"]))
-		opCfg.Section("operator").NewKey("lb_priv_key", b64.StdEncoding.EncodeToString(lbSecret.Data["tls.key"]))
+		FillKeyIfPresent(opCfg, "operator", "lb_default_cert", lbSecret.Data["tls.crt"])
+		FillKeyIfPresent(opCfg, "operator", "lb_priv_key", lbSecret.Data["tls.key"])
+	}
+	if nsxSecret != nil {
+		FillKeyIfPresent(opCfg, "operator", "nsx_api_cert", nsxSecret.Data["tls.crt"])
+		FillKeyIfPresent(opCfg, "operator", "nsx_api_private_key", nsxSecret.Data["tls.key"])
+		FillKeyIfPresent(opCfg, "operator", "nsx_ca", nsxSecret.Data["tls.ca"])
 	}
 
 	opConfigmap.Data[operatortypes.ConfigMapDataKey], err = iniWriteToString(opCfg)

--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -266,8 +266,14 @@ func TestGenerateOperatorConfigMap(t *testing.T) {
 	lbSecret.Data = make(map[string][]byte)
 	lbSecret.Data["tls.crt"] = []byte("mockCrt")
 	lbSecret.Data["tls.key"] = []byte("mockKey")
+	nsxSecret := &corev1.Secret{}
+	nsxSecret.Data = make(map[string][]byte)
+	nsxSecret.Data["tls.crt"] = []byte("mockCrt")
+	nsxSecret.Data["tls.key"] = []byte("mockKey")
+	nsxSecret.Data["tls.ca"] = []byte("mockCA")
 
-	GenerateOperatorConfigMap(opConfigMap, ncpConfigMap, agentConfigMap, lbSecret)
+
+	GenerateOperatorConfigMap(opConfigMap, ncpConfigMap, agentConfigMap, lbSecret, nsxSecret)
 	data = &opConfigMap.Data
 	cfg, _ = ini.Load([]byte((*data)[operatortypes.ConfigMapDataKey]))
 	assert.Equal(t, "mockIP", cfg.Section("nsx_v3").Key("nsx_api_managers").Value())
@@ -276,6 +282,12 @@ func TestGenerateOperatorConfigMap(t *testing.T) {
 		cfg.Section("operator").Key("lb_default_cert").Value())
 	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("mockKey")),
 		cfg.Section("operator").Key("lb_priv_key").Value())
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("mockCrt")),
+		cfg.Section("operator").Key("nsx_api_cert").Value())
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("mockKey")),
+		cfg.Section("operator").Key("nsx_api_private_key").Value())
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("mockCA")),
+		cfg.Section("operator").Key("nsx_ca").Value())
 }
 
 func TestIniWriteToString(t *testing.T) {

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -199,10 +199,18 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 			}
 			lbSecret = nil
 		}
+		nsxSecret := &corev1.Secret{}
+		err = r.client.Get(context.TODO(), types.NamespacedName{Namespace: operatortypes.NsxNamespace, Name: operatortypes.NsxSecret}, nsxSecret)
+		if err != nil {
+			if !apierrors.IsNotFound(err) {
+				log.Error(err, "Failed to get nsx-secret")
+			}
+			nsxSecret = nil
+		}
 		if ncpConfigMap != nil && agentConfigMap != nil {
 			appliedConfigMap = &corev1.ConfigMap{}
 			appliedConfigMap.Data = make(map[string]string)
-			err = GenerateOperatorConfigMap(appliedConfigMap, ncpConfigMap, agentConfigMap, lbSecret)
+			err = GenerateOperatorConfigMap(appliedConfigMap, ncpConfigMap, agentConfigMap, lbSecret, nsxSecret)
 			if err != nil {
 				r.status.SetDegraded(statusmanager.OperatorConfig, "InternalError",
 					fmt.Sprintf("Failed to generate operator ConfigMap: %v", err))

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -26,6 +26,7 @@ const (
 	NsxCertRenderKey            string = "NsxCert"
 	NsxKeyRenderKey             string = "NsxKey"
 	NsxCARenderKey              string = "NsxCA"
+	NsxSecret                   string = "nsx-secret"
 	NsxCertTempPath             string = "/tmp/nsx.cert"
 	NsxKeyTempPath              string = "/tmp/nsx.key"
 	NsxCATempPath               string = "/tmp/nsx.ca"


### PR DESCRIPTION
Retrieve nsx-secret to generate applied operator configmap for
checking if the configmap changed, in case the NCP pod is re-created
everytime when the operator starts.