### PR TITLE
Skip checking port which doesn't have realized bindings

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -185,7 +185,7 @@ func filterSegmentPorts(nsxClients *NsxClients, ports []*data.StructValue, nodeN
 			return -1, err
 		}
 		if len(logicalPort.RealizedBindings) == 0 {
-			return -1, errors.Errorf("Segment port %s doesn't have realized bindings", portPolicyId)
+			continue
 		}
 		address := logicalPort.RealizedBindings[0].Binding.IpAddress
 		if address == nodeAddress {


### PR DESCRIPTION
When the operator tries to checked segment ports to tag for nodes,
it will skip handling the port with empty realized bindings.