### PR TITLE
Set no degraded after the network status is successfully updated

### DIFF
--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -275,8 +275,8 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 				if err != nil {
 					r.status.SetDegraded(statusmanager.ClusterConfig, "UpdateNetworkStatusError",
 						fmt.Sprintf("Failed to update network status: %v", err))
+						return reconcile.Result{}, err
 				}
-				return reconcile.Result{}, err
 			}
 			r.status.SetNotDegraded(statusmanager.ClusterConfig)
 			r.status.SetNotDegraded(statusmanager.OperatorConfig)


### PR DESCRIPTION
In some case, the UpdateNetworkStatusError cannot be removed and the
clusteroperator nsx-ncp gets stuck in degraded status, this patch will
fix this issue.