### PR TITLE
Fix incorrectly placed else in update_network_status

### DIFF
--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -403,10 +403,10 @@ func updateNetworkStatus(networkConfig *configv1.Network, configMap *corev1.Conf
 			log.Error(err, fmt.Sprintf("Could not apply (%s) %s/%s", data.GroupVersionKind(),
 				data.GetNamespace(), data.GetName()))
 			return err
-		} else {
-			log.Error(err, "Retrieved data for updating network status is empty.")
-			return err
 		}
+	} else {
+		log.Error(err, "Retrieved data for updating network status is empty.")
+		return err
 	}
 	log.Info("Successfully updated Network Status")
 	return nil


### PR DESCRIPTION
A misplaced else was causing an error to be logged even if the
network status was successfully updated.