### PR TITLE
Wait longer time to ensure the network status is really recovered

### DIFF
--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -180,7 +180,7 @@ func (r *ReconcilePod) Reconcile(request reconcile.Request) (reconcile.Result, e
 
 	reqLogger.Info("Reconciling pod update")
 	r.status.SetFromPodsForOverall()
-	r.status.SetNodeConditionFromPods()
+	r.status.SetNodeConditionFromPods(r.sharedInfo)
 
 	if err := r.recreateNsxNcpResourceIfDeleted(request.Name); err != nil {
 		return reconcile.Result{Requeue: true}, err

--- a/pkg/controller/sharedinfo/shared_info.go
+++ b/pkg/controller/sharedinfo/shared_info.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"gopkg.in/ini.v1"
 
@@ -25,6 +26,7 @@ var log = logf.Log.WithName("shared_info")
 type SharedInfo struct {
 	AdaptorName           string
 	AddNodeTag            bool
+	LastNetworkAvailable   map[string]time.Time
 	NetworkConfig         *configv1.Network
 	OperatorConfigMap     *corev1.ConfigMap
 	OperatorNsxSecret     *corev1.Secret

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -33,4 +33,5 @@ const (
 	NsxCATempPath               string = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName   string = "nsx-node-agent"
 	OsReleaseFile               string = "/host/etc/os-release"
+	TimeBeforeRecoverNetwork    int64  = 150
 )


### PR DESCRIPTION
When the operator tries to update NetworkUnavaible from false to true,
it will wait 150 seconds to ensure that the nsx-node-agent is really
healthy as the liveness probe doesn't fail.