### PR TITLE
Remove files link for yamls in /deploy

### DIFF
--- a/deploy/openshift4/lb-secret.yaml
+++ b/deploy/openshift4/lb-secret.yaml
@@ -1,1 +1,5 @@
-../kubernetes/lb-secret.yaml
+apiVersion: v1
+data: {tls.crt: "", tls.key: ""}
+kind: Secret
+metadata: {name: lb-secret, namespace: nsx-system-operator}
+type: kubernetes.io/tls

--- a/deploy/openshift4/nsx-secret.yaml
+++ b/deploy/openshift4/nsx-secret.yaml
@@ -1,1 +1,5 @@
-../kubernetes/nsx-secret.yaml
+apiVersion: v1
+data: {tls.crt: "", tls.key: "", tls.ca: ""}
+kind: Secret
+metadata: {name: nsx-secret, namespace: nsx-system-operator}
+type: kubernetes.io/tls

--- a/deploy/openshift4/role_binding.yaml
+++ b/deploy/openshift4/role_binding.yaml
@@ -1,1 +1,12 @@
-../kubernetes/role_binding.yaml
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: nsx-ncp-operator
+subjects:
+- kind: ServiceAccount
+  name: nsx-ncp-operator
+  namespace: nsx-system-operator
+roleRef:
+  kind: ClusterRole
+  name: nsx-ncp-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/openshift4/service_account.yaml
+++ b/deploy/openshift4/service_account.yaml
@@ -1,1 +1,5 @@
-../kubernetes/service_account.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nsx-ncp-operator
+  namespace: nsx-system-operator


### PR DESCRIPTION
The user will fail to get the file content from
raw.githubusercontent.com if we use the links.

This patch will remove the links and use the real
files as a replacement.