### PR TITLE
Extend the waiting time to ensure pod health

### DIFF
--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -33,5 +33,5 @@ const (
 	NsxCATempPath               string = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName   string = "nsx-node-agent"
 	OsReleaseFile               string = "/host/etc/os-release"
-	TimeBeforeRecoverNetwork    int64  = 150
+	TimeBeforeRecoverNetwork    int64  = 450
 )


### PR DESCRIPTION
The original time is not enough because in tests,
it takes about 6 minutes that nsx-node-agent pod's
status change from Running to CrashLoopBackOff.