### PR TITLE
Ignore the empty manifest during applying objects

### DIFF
--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -358,6 +358,9 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 
 	// Apply objects to K8s cluster
 	for _, obj := range objs {
+		if len(obj.GetName()) == 0 {
+			continue
+		}
 		// Mark the object to be GC'd if the owner is deleted
 		err = r.setControllerReference(r, networkConfig, obj)
 		if err != nil {


### PR DESCRIPTION
The render lib will got an empty manifest because there's
addtional "---" in all-in-one yaml. This patch will filter
out that kind of invalid manifest.