### PR TITLE
Set latest tag when building operator image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ OPERATOR_IMG_NAME = vmware/nsx-container-plugin-operator
 build:
 	GOOS=linux $(GO) build -o $(BINDIR)/$(OPERATOR_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./cmd/manager
 	docker build -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION)
+	docker tag $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION) $(OPERATOR_IMG_NAME)
 
 .PHONY: bin
 bin:


### PR DESCRIPTION
This will ensure the image built is also pushed to the
target registry