### PR TITLE
Fix Makefile to preserve nsx-ncp-operator as binary the name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,13 @@ all: build
 include versioning.mk
 
 LDFLAGS += $(VERSION_LDFLAGS)
-OPERATOR_NAME = vmware/nsx-container-plugin-operator
+OPERATOR_NAME = nsx-ncp-operator
+OPERATOR_IMG_NAME = vmware/nsx-container-plugin-operator
 
 .PHONY: build
 build:
 	GOOS=linux $(GO) build -o $(BINDIR)/$(OPERATOR_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./cmd/manager
-	docker build -f build/Dockerfile . -t $(OPERATOR_NAME):$(DOCKER_IMG_VERSION)
+	docker build -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION)
 
 .PHONY: bin
 bin:


### PR DESCRIPTION
PR #93 renamed not only the image name, but also the executable