### PR TITLE
Check and create NCP resources at startup

### DIFF
--- a/pkg/controller/pod/pod_controller_test.go
+++ b/pkg/controller/pod/pod_controller_test.go
@@ -356,18 +356,6 @@ func TestPodControllerReconcile(t *testing.T) {
 	r.testReconcileOnCLBNsxNodeAgentInvalidResolvConf(t)
 }
 
-func TestPodController_identifyAndGetInstance(t *testing.T) {
-	if !reflect.DeepEqual(identifyAndGetInstance(operatortypes.NsxNcpDeploymentName), &appsv1.Deployment{}) {
-		t.Fatalf("nsx-ncp instance must be a Deployment")
-	}
-	if !reflect.DeepEqual(identifyAndGetInstance(operatortypes.NsxNcpBootstrapDsName), &appsv1.DaemonSet{}) {
-		t.Fatalf("nsx-ncp instance must be a DaemonSet")
-	}
-	if !reflect.DeepEqual(identifyAndGetInstance(operatortypes.NsxNodeAgentDsName), &appsv1.DaemonSet{}) {
-		t.Fatalf("nsx-ncp instance must be a DaemonSet")
-	}
-}
-
 func TestPodController_deletePods(t *testing.T) {
 	c := fake.NewFakeClient()
 	nodeAgentPod := &corev1.Pod{

--- a/pkg/types/utils.go
+++ b/pkg/types/utils.go
@@ -1,0 +1,47 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package types
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CheckIfNCPK8sResourceExists infers the k8s object from resName and checks
+// if it exists
+func CheckIfNCPK8sResourceExists(
+	c client.Client, resName string) (bool, error) {
+	instance, err := identifyAndGetInstance(resName)
+	if err != nil {
+		return false, err
+	}
+	instanceDetails := types.NamespacedName{
+		Namespace: NsxNamespace,
+		Name:      resName,
+	}
+	err = c.Get(context.TODO(), instanceDetails, instance)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func identifyAndGetInstance(resName string) (runtime.Object, error) {
+	if resName == NsxNcpBootstrapDsName || resName == NsxNodeAgentDsName {
+		return &appsv1.DaemonSet{}, nil
+	} else if resName == NsxNcpDeploymentName {
+		return &appsv1.Deployment{}, nil
+	}
+	return nil, errors.Errorf("failed to identify instance for: %s", resName)
+}

--- a/pkg/types/utils_test.go
+++ b/pkg/types/utils_test.go
@@ -1,0 +1,65 @@
+/* Copyright © 2021 VMware, Inc. All Rights Reserved.
+   SPDX-License-Identifier: Apache-2.0 */
+
+package types
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestUtils_identifyAndGetInstance(t *testing.T) {
+	instance, err := identifyAndGetInstance(
+		NsxNcpDeploymentName)
+	if !reflect.DeepEqual(instance, &appsv1.Deployment{}) {
+		t.Fatalf("nsx-ncp instance must be a Deployment")
+	}
+	instance, err = identifyAndGetInstance(
+		NsxNcpBootstrapDsName)
+	if !reflect.DeepEqual(instance, &appsv1.DaemonSet{}) {
+		t.Fatalf("nsx-ncp instance must be a DaemonSet")
+	}
+	instance, err = identifyAndGetInstance(
+		NsxNodeAgentDsName)
+	if !reflect.DeepEqual(instance, &appsv1.DaemonSet{}) {
+		t.Fatalf("nsx-ncp instance must be a DaemonSet")
+	}
+	instance, err = identifyAndGetInstance(
+		"new-k8s-resource")
+	if err == nil {
+		t.Fatalf("identifyAndGetInstance: (%v)", err)
+	}
+}
+
+func TestUtils_CheckIfNCPK8sResourceExists(t *testing.T) {
+	c := fake.NewFakeClient()
+	// NCP resource does not exist
+	resExists, err := CheckIfNCPK8sResourceExists(c, NsxNodeAgentDsName)
+	if err != nil {
+		t.Fatalf("CheckIfNCPK8sResourceExists: (%v)", err)
+	}
+	if resExists {
+		t.Fatalf("nsx-node-agent does not exist but client found it: %v", err)
+	}
+
+	// NCP resource exists
+	ncpDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nsx-ncp",
+			Namespace: "nsx-system",
+		},
+	}
+	c.Create(context.TODO(), ncpDeployment)
+	resExists, err = CheckIfNCPK8sResourceExists(c, NsxNcpDeploymentName)
+	if err != nil {
+		t.Fatalf("CheckIfNCPK8sResourceExists: (%v)", err)
+	}
+	if !resExists {
+		t.Fatalf("nsx-ncp exists but client could not find it: %v", err)
+	}
+}


### PR DESCRIPTION
The user can delete nsx-ncp deployment or nsx-node-agent, nsx-ncp-bootstrap
Daemon Sets. If they are deleted when the operator is not running, the
operator should create them upon startup