### PR TITLE
[IPI] Disable coredns before local apiserver ready in master nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ Create manifest files:
 ```
 $ openshift-install --dir=MY_CLUSTER create manifests
 ```
-Put operator yaml files from `deploy/openshift4/` to `MY_CLUSTER/manifests`,
+Copy operator yaml files from `deploy/openshift4/` to `MY_CLUSTER/manifests`,
 edit configmap.yaml about operator configurations, add the operator image and
-NCP image in operator.yaml.
+NCP image in operator.yaml. Note `deploy/openshift4/nsx-ipi-helper.yaml` is only
+for IPI, if you are using UPI please don't copy it.
 
 Generate ignition configuration files:
 ```

--- a/deploy/openshift4/nsx-ipi-helper.yaml
+++ b/deploy/openshift4/nsx-ipi-helper.yaml
@@ -1,0 +1,58 @@
+# nsx-ipi-helper DaemonSet
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nsx-ipi-helper
+  namespace: nsx-system-operator
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      name: nsx-ipi-helper
+  template:
+    metadata:
+      labels:
+        name: nsx-ipi-helper
+    spec:
+      hostNetwork: true
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: node.kubernetes.io/not-ready
+          effect: NoSchedule
+        - key: node.kubernetes.io/unreachable
+          effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      volumes:
+        - name: host-manifests
+          hostPath:
+            path: "/etc/kubernetes/manifests"
+      initContainers:
+        - name: nsx-ipi-helper
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          imagePullPolicy: IfNotPresent
+          command:
+          - bin/bash
+          - -c
+          - |
+            while true; do
+              sed -i "s/-f \/etc\/keepalived\/keepalived.conf/-f \/etc\/keepalived\/fake_keepalived.conf/" /etc/kubernetes/manifests/keepalived.yaml && echo `date` Temporarily disabled keepalived
+              if /usr/bin/curl -kLfs https://localhost:6443/readyz; then
+                sed -i "s/fake_keepalived.conf/keepalived.conf/" /etc/kubernetes/manifests/keepalived.yaml
+                echo `date` Restored the keepalived in localhost
+                exit 0
+              fi
+              sleep 1
+            done
+          volumeMounts:
+            - name: host-manifests
+              mountPath: "/etc/kubernetes/manifests"
+          securityContext:
+            privileged: true
+      containers:
+        - name: nsx-ipi-dummy
+          image: registry.access.redhat.com/ubi8/ubi:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/bin/bash", "-c", "while true; do sleep 5; done"]


### PR DESCRIPTION
Currently, for OpenShift IPI, there will be a static pod keepalived
adding the Kubernetes VIP to the ovs_bridge on the master nodes and
the coredns pod running on every nodes to redirect the API request
to the VIP. However, the VIP works too early when the API server is
still only on bootstrap node and the port 6443 on master nodes are
not ready.

For the solution, there're 5 feasible manual workarounds:

1. Add the bootstrap IP to /etc/hosts on every master nodes then
   remove them when the apiserver on local becomes ready;
2. Deploy a forwarder on every master nodes to listen port 6443 and
   forward the traffic to bootstrap node;
3. Add an iptables rule on the port 53 of master nodes to temporarily
   make the coredns invalid then the apiserver can be resolved by
   external DNS server;
4. Change the order in /etc/resolv.conf to make the external DNS
   server at the top of local coredns, then the API server address
   will be resolved by external DNS server instead of local DNS.
5. Temperarily hack the static pod's yaml file for kubelet in master
   node to disable the keepalived, then restore them after local API
   server is ready.

To automate the above workarounds, for 1 and 2, it's complex to get the
accurate bootstrap IP; for 3 and 4, the DNS server should know the
bootstrap's IP but it knows only the VIP if the user is following
the official doc, and the /etc/resolv.conf is automatically generated by
NM so persisting it needs more effort. For 5, we need to change the
files in node, it's tricky. Taking into account the difficulties of user
configuration our changess, this patch is based on method 5. It will
create deamonset to deploy the pod on every master node then hack
the definiation of keepalived in /etc/kubernetes/manifests/keepalived.yaml
until loalhost:6443 is up.

The usage:
For the IPI customer, the deploy/openshift4/nsx-ipi-helper.yaml
should be additionally deployed. The customer not using IPI won't be
impacted.