### PR TITLE
Improve the resync logic for node network status

### DIFF
--- a/pkg/controller/pod/pod_controller_test.go
+++ b/pkg/controller/pod/pod_controller_test.go
@@ -174,8 +174,8 @@ func (r *ReconcilePod) testReconcileOnWatchedResource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	if res.RequeueAfter != ResyncPeriod {
-		t.Fatalf("reconcile should requeue the request after %v", ResyncPeriod)
+	if res.RequeueAfter != operatortypes.DefaultResyncPeriod {
+		t.Fatalf("reconcile should requeue the request after %v", operatortypes.DefaultResyncPeriod)
 	}
 	r.client.Delete(context.TODO(), ncpDeployment)
 }
@@ -213,8 +213,8 @@ func (r *ReconcilePod) testReconcileOnWatchedResourceWhenDeleted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	if res.RequeueAfter != ResyncPeriod {
-		t.Fatalf("reconcile should requeue the request after %v", ResyncPeriod)
+	if res.RequeueAfter != operatortypes.DefaultResyncPeriod {
+		t.Fatalf("reconcile should requeue the request after %v", operatortypes.DefaultResyncPeriod)
 	}
 
 	// Validate that reconcile recreated the deployment
@@ -289,9 +289,9 @@ func (r *ReconcilePod) testReconcileOnCLBNsxNodeAgentInvalidResolvConf(
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	if res.RequeueAfter != ResyncPeriod {
+	if res.RequeueAfter != operatortypes.DefaultResyncPeriod {
 		t.Fatalf("reconcile should requeue the request after %v but it did "+
-			"after %v", ResyncPeriod, res.RequeueAfter)
+			"after %v", operatortypes.DefaultResyncPeriod, res.RequeueAfter)
 	}
 	obj := &corev1.Pod{}
 	namespacedName := types.NamespacedName{
@@ -336,9 +336,9 @@ func (r *ReconcilePod) testReconcileOnCLBNsxNodeAgentInvalidResolvConf(
 	if err != nil {
 		t.Fatalf("reconcile: (%v)", err)
 	}
-	if res.RequeueAfter != ResyncPeriod {
+	if res.RequeueAfter != operatortypes.DefaultResyncPeriod {
 		t.Fatalf("reconcile should requeue the request after %v but it did "+
-			"after %v", ResyncPeriod, res.RequeueAfter)
+			"after %v", operatortypes.DefaultResyncPeriod, res.RequeueAfter)
 	}
 	obj = &corev1.Pod{}
 	err = c.Get(context.TODO(), namespacedName, obj)

--- a/pkg/controller/sharedinfo/shared_info.go
+++ b/pkg/controller/sharedinfo/shared_info.go
@@ -26,7 +26,6 @@ var log = logf.Log.WithName("shared_info")
 type SharedInfo struct {
 	AdaptorName               string
 	AddNodeTag                bool
-	LastNetworkAvailable      map[string]time.Time
 	LastNodeAgentStartTime    map[string]time.Time
 	NetworkConfig             *configv1.Network
 	OperatorConfigMap         *corev1.ConfigMap

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -36,4 +36,5 @@ const (
 	NsxNodeAgentContainerName    string         = "nsx-node-agent"
 	OsReleaseFile                string         = "/host/etc/os-release"
 	TimeBeforeRecoverNetwork     time.Duration  = 180 * time.Second
+	DefaultResyncPeriod          time.Duration  = 2 * time.Minute
 )


### PR DESCRIPTION
Sometimes when a nsx-node-agent pod is created and
running for less than 180 seconds, the operator will
try to update the node status twice (firstly set
network-unavailable=true, then sleep and try to set
network-unavailable=false after 180 seconds)[1].

The code has a redundant check before sleeping, and
in the check logic, Get API reads the node status
from cache which may be not synced after the first
update operation was executed, so an unexpected
"Node condition is not changed" will be reported,
then the taints cannot be removed until the removal
logic was triggerred accidentally by another event
from nsx-node-agent pod. This patch will remove the
redundant check.

And we will assume that the data read by client will
eventually be correct, but may be slightly out of
date. So this patch introduced the logic
assertNodeStatus to ensure the final status is
expected.

This patch also replace the goroutine with RequeueAfter,
the latter is a more native and less error-prone
implementation.

[1] The following logs show this case:

{"level":"info","ts":"2021-03-08T14:56:37.864Z","logger":"status_manager","msg":"nsx-node-agent-p8ss5/nsx-kube-proxy for node compute-2 started for less than 17.864554094s"}
{"level":"info","ts":"2021-03-08T14:56:37.864Z","logger":"status_manager","msg":"nsx-node-agent-p8ss5/nsx-node-agent for node compute-2 started for less than 17.864554094s"}
{"level":"info","ts":"2021-03-08T14:56:37.864Z","logger":"status_manager","msg":"nsx-node-agent-p8ss5/nsx-ovs for node compute-2 started for less than 17.864554094s"}
{"level":"info","ts":"2021-03-08T14:56:37.864Z","logger":"status_manager","msg":"Setting status NetworkUnavailable to true for node compute-2"}
{"level":"info","ts":"2021-03-08T14:56:37.876Z","logger":"status_manager","msg":"Updated node condition NetworkUnavailable to true for node compute-2"}
{"level":"info","ts":"2021-03-08T14:56:37.876Z","logger":"status_manager","msg":"Node condition is not changed"}
...
{"level":"info","ts":"2021-03-08T15:26:13.541Z","logger":"status_manager","msg":"Setting status NetworkUnavailable to false for node compute-2"}
{"level":"info","ts":"2021-03-08T15:26:13.541Z","logger":"status_manager","msg":"Setting status NetworkUnavailable to false for node compute-2 after -26m53.541741583s"}