### PR TITLE
Handle pod status StartTime access when it's not initilized

### DIFF
--- a/pkg/controller/statusmanager/pod_status.go
+++ b/pkg/controller/statusmanager/pod_status.go
@@ -98,7 +98,7 @@ func SetNodeCondition(conditions *[]corev1.NodeCondition, newCondition corev1.No
 // CheckExistingAgentPods is for a case: nsx-node-agent becomes unhealthy -> NetworkUnavailable=True -> operator off ->
 // nsx-node-agent becomes healthy and keeps running -> operator up -> operator cannot receive nsx-node-agent event to
 // set NetworkUnavailable=False. So a full sync at the start time is necessary.
-func (status *StatusManager) CheckExistingAgentPods (firstBoot *bool, sharedInfo *sharedinfo.SharedInfo) error {
+func (status *StatusManager) CheckExistingAgentPods(firstBoot *bool, sharedInfo *sharedinfo.SharedInfo) error {
 	status.Lock()
 	defer status.Unlock()
 
@@ -213,7 +213,6 @@ func (status *StatusManager) updateNodeStatus(nodeName string, ready bool, reaso
 	}
 }
 
-
 // Get the pod status from API server
 func (status *StatusManager) SetNodeConditionFromPod(podName types.NamespacedName, sharedInfo *sharedinfo.SharedInfo, pod *corev1.Pod) {
 	status.Lock()
@@ -247,13 +246,16 @@ func (status *StatusManager) setNodeConditionFromPod(podName types.NamespacedNam
 	// received the outdated pot event after the new pod running. For this case
 	// we should ignore the outdated event, otherwise, the operator may mistakenly
 	// set the NetworkUnavailbe status.
-	podStartedAt := pod.Status.StartTime.Time
-	nodeLastStartedAt := sharedInfo.LastNodeAgentStartTime[nodeName]
-	if podStartedAt.Before(nodeLastStartedAt) {
-		log.Info("Pod %s started at %v on node %s is outdated, there's new pod started at %v", podStartedAt, podName, nodeName, nodeLastStartedAt)
-		return
-	} else {
-		sharedInfo.LastNodeAgentStartTime[nodeName] = podStartedAt
+	// StartTime field will not be set until pod is initilized in pending state
+	if (pod.Status.StartTime != nil) {
+		podStartedAt := pod.Status.StartTime.Time
+		nodeLastStartedAt := sharedInfo.LastNodeAgentStartTime[nodeName]
+		if podStartedAt.Before(nodeLastStartedAt) {
+			log.Info(fmt.Sprintf("Pod %s started at %v on node %s is outdated, there's new pod started at %v", podName, podStartedAt, nodeName, nodeLastStartedAt))
+			return
+		} else {
+			sharedInfo.LastNodeAgentStartTime[nodeName] = podStartedAt
+		}
 	}
 
 	// when pod is pending, its ContainerStatuses is empty


### PR DESCRIPTION
**The issue brief:**
This issue was found during test to access pod status startTime field: which led to operator crash and restarted.
test log as below:
{"level":"info","ts":"2021-03-14T07:24:03.290Z","logger":"controller_node","msg":"Getting config from operator configmap"}
{"level":"info","ts":"2021-03-14T07:24:03.292Z","logger":"controller-runtime.controller","msg":"Starting workers","controller":"pod-controller","worker count":1}
{"level":"info","ts":"2021-03-14T07:24:03.292Z","logger":"status_manager","msg":"Checking all nsx-node-agent pods for node condition"}
E0314 07:24:03.292817 1 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 704 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x18cc400, 0x2a38050)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/k8s.io/apimachinery@v0.17.1/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/k8s.io/apimachinery@v0.17.1/pkg/util/runtime/runtime.go:48 +0x82
panic(0x18cc400, 0x2a38050)
/root/go/src/runtime/panic.go:679 +0x1b2
github.com/vmware/nsx-container-plugin-operator/pkg/controller/statusmanager.(*StatusManager).setNodeConditionFromPod(0xc0002cd5f0, 0x0, 0x0, 0x0, 0x0, 0xc000863680, 0xc000a0b000)
/tmp/nsx-ujo/images/nsx-container-plugin-operator/pkg/controller/statusmanager/pod_status.go:250 +0xc9
github.com/vmware/nsx-container-plugin-operator/pkg/controller/statusmanager.(*StatusManager).CheckExistingAgentPods(0xc0002cd5f0, 0x29cb2d8, 0xc000863680, 0x0, 0x0)
/tmp/nsx-ujo/images/nsx-container-plugin-operator/pkg/controller/statusmanager/pod_status.go:131 +0x310
github.com/vmware/nsx-container-plugin-operator/pkg/controller/pod.(*ReconcilePod).Reconcile(0xc0003a6690, 0xc0005c0060, 0x21, 0xc0002b2940, 0x15, 0xc000586cd8, 0xc0003cfa70, 0xc002c6e008, 0x1d8c340)
/tmp/nsx-ujo/images/nsx-container-plugin-operator/pkg/controller/pod/pod_controller.go:193 +0x142
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000166c00, 0x1940780, 0xc00039a160, 0xc000230500)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000166c00, 0x0)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000166c00)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc000b80ab0)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/k8s.io/apimachinery@v0.17.1/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000b80ab0, 0x3b9aca00, 0x0, 0x45d301, 0xc0002d8180)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/k8s.io/apimachinery@v0.17.1/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc000b80ab0, 0x3b9aca00, 0xc0002d8180)
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/k8s.io/apimachinery@v0.17.1/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
/build/mts/release/bora-17559186/home/mts/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/internal/controller/controller.go:193 +0x328
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1334219]

**The issue investigation:**
We have found the root cause for this crash issue, which is caused by pod.Status.StartTime to check nsx-node-agent pods in funcation:setNodeConditionFromPod
https://github.com/vmware/nsx-container-plugin-operator/blob/master/pkg/controller/statusmanager/pod_status.go#L250
In short, pod.Status.StartTime is represented as time at which the object was acknowledged by the Kubelet. This is before the Kubelet pulled the container image(s) for the pod. When pod is in pending state before initialized, this field is nil not set. If we access the pod during this transition time , it will lead to operator crash since we don't check this situation.
The detailed triage as below:
nsx-system nsx-node-agent-449ph 2/3 CrashLoopBackOff 255 22h
nsx-system nsx-node-agent-j58kc 3/3 Running 0 100s
nsx-system nsx-node-agent-pgstc 3/3 Running 7653 28d
kubectl describe pod -n nsx-node-agent-449ph -o yaml > node-agent-449ph.yaml
Add nodeSelector in node-agent-449ph.yaml to make pod unable to be scheduled when creation.
nodeSelector:
vm: master1
and then recreate a nsx-node-agent
root@wdc-rdops-vm05-dhcp-86-61:~# kc replace --force -f agent-449ph.yaml
pod "nsx-node-agent-449ph" deleted
We have added some info in setNodeConditionFromPod to print more detailed info just before accessing the pod.Status.StartTime.
{"level":"info","ts":"2021-03-23T10:45:16.395Z","logger":"controller_pod","msg":"Reconciling pod update for network status","Request.Namespace":"nsx-system","Request.Name":"nsx-node-agent-85bg4"}
{"level":"info","ts":"2021-03-23T10:45:16.395Z","logger":"status_manager","msg":"setNodeConditionFromPod nsx-system/nsx-node-agent-85bg4 nsx-node-agent-85bg4"}
{"level":"info","ts":"2021-03-23T10:45:16.396Z","logger":"status_manager","msg":"setNodeConditionFromPod pod nsx-node-agent-85bg4 Status {Pending [] [] [] [] BestEffort []}"}
{"level":"info","ts":"2021-03-23T10:45:16.398Z","logger":"status_manager","msg":"setNodeConditionFromPod pod nsx-node-agent-85bg4 Status.StartTime "}
....
{"level":"info","ts":"2021-03-23T10:45:16.418Z","logger":"status_manager","msg":"setNodeConditionFromPod nsx-system/nsx-node-agent-85bg4 nsx-node-agent-85bg4"}
{"level":"info","ts":"2021-03-23T10:45:16.418Z","logger":"status_manager","msg":"setNodeConditionFromPod pod nsx-node-agent-85bg4 Status {Pending [{PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2021-03-23 10:45:16 +0000 UTC }] [] [] [] BestEffort []}"}
{"level":"info","ts":"2021-03-23T10:45:16.418Z","logger":"status_manager","msg":"setNodeConditionFromPod pod nsx-node-agent-85bg4 Status.StartTime "}
.....
{"level":"info","ts":"2021-03-23T10:45:16.553Z","logger":"controller_pod","msg":"Reconciling pod update for network status","Request.Namespace":"nsx-system","Request.Name":"nsx-node-agent-85bg4"}
{"level":"info","ts":"2021-03-23T10:45:16.553Z","logger":"status_manager","msg":"setNodeConditionFromPod nsx-system/nsx-node-agent-85bg4 nsx-node-agent-85bg4"}
{"level":"info","ts":"2021-03-23T10:45:16.553Z","logger":"status_manager","msg":"setNodeConditionFromPod pod nsx-node-agent-85bg4 Status {Pending [{Initialized True 0001-01-01 00:00:00 +0000 UTC 2021-03-23 10:45:16 +0000 UTC } {Ready False 0001-01-01 00:00:00 +0000 UTC 2021-03-23 10:45:16 +0000 UTC ContainersNotReady containers with unready status: [nsx-node-agent nsx-kube-proxy nsx-ovs]} {ContainersReady False 0001-01-01 00:00:00 +0000 UTC 2021-03-23 10:45:16 +0000 UTC ContainersNotReady containers with unready status: [nsx-node-agent nsx-kube-proxy nsx-ovs]} {PodScheduled True 0001-01-01 00:00:00 +0000 UTC 2021-03-23 10:45:16 +0000 UTC }] 172.10.0.2 172.10.0.2 [{172.10.0.2}] 2021-03-23 10:45:16 +0000 UTC [] [{nsx-kube-proxy {&ContainerStateWaiting{Reason:ContainerCreating,Message:,} nil nil} {nil nil nil} false 0 nsx-ncp:latest 0xc00092401d} {nsx-node-agent {&ContainerStateWaiting{Reason:ContainerCreating,Message:,} nil nil} {nil nil nil} false 0 nsx-ncp:latest 0xc00092401e} {nsx-ovs {&ContainerStateWaiting{Reason:ContainerCreating,Message:,} nil nil} {nil nil nil} false 0 nsx-ncp:latest 0xc00092401f}] BestEffort []}"}
{"level":"info","ts":"2021-03-23T10:45:16.553Z","logger":"status_manager","msg":"setNodeConditionFromPod pod nsx-node-agent-85bg4 Status.StartTime 2021-03-23 10:45:16 +0000 UTC"}
As we can see, new created pod:Status.StartTime is nsx-node-agent-85bg4 is nil until it's Initialized in pending state. both the very beginning of pending state and PodScheduled of the pending state will be nil.

**Fix Solution:**
Add nil check for pod.Status.StartTime field to make program more robust to avoid crash.

