### PR TITLE
Immediately respond when the customer correct error in role

### DIFF
--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -8,6 +8,7 @@ import "time"
 const (
 	OperatorNamespace            string         = "nsx-system-operator"
 	ConfigMapName                string         = "nsx-ncp-operator-config"
+	OperatorRoleName             string         = "nsx-ncp-operator"
 	NcpInstallCRDName            string         = "ncp-install"
 	NetworkCRDName               string         = "cluster"
 	NsxNamespace                 string         = "nsx-system"


### PR DESCRIPTION
The previous error handling logic is that when the operator hit
error during applying configuration, the reconciler will receive
an error then requeue the request. However, the requeue mechanism
has a potential backoff, that caused the operator may not
immediately respond when the customer correct error in operator's
cluster role.

This patch will additional watch the cluster role change for
the immediate response.