### PR TITLE
Improvements for SecretNotEqual function

### DIFF
--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -806,8 +806,10 @@ spec:
                       path: nsx-cert/tls.crt
                     - key: tls.key
                       path: nsx-cert/tls.key
+{{if .NsxCA}}
                     - key: tls.ca
                       path: nsx-cert/tls.ca
+{{end}}
 
 
               - secret:

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -806,8 +806,10 @@ spec:
                       path: nsx-cert/tls.crt
                     - key: tls.key
                       path: nsx-cert/tls.key
+{{if .NsxCA}}
                     - key: tls.ca
                       path: nsx-cert/tls.ca
+{{end}}
 
 
               - secret:

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -605,8 +605,10 @@ spec:
                       path: nsx-cert/tls.crt
                     - key: tls.key
                       path: nsx-cert/tls.key
+{{if .NsxCA}}
                     - key: tls.ca
                       path: nsx-cert/tls.ca
+{{end}}
 
 
               - secret:

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -346,6 +346,8 @@ func Render(configmap *corev1.ConfigMap, ncpReplicas *int32, nsxSecret *corev1.S
 		// Render tls.ca only if specified
 		if tls_ca, found := nsxSecret.Data["tls.ca"]; found {
 			renderData.Data[operatortypes.NsxCARenderKey] = base64.StdEncoding.EncodeToString(tls_ca)
+		} else {
+			renderData.Data[operatortypes.NsxCARenderKey] = ""
 		}
 	} else {
 		renderData.Data[operatortypes.NsxCertRenderKey] = ""

--- a/pkg/controller/configmap/configmap_controller_test.go
+++ b/pkg/controller/configmap/configmap_controller_test.go
@@ -132,13 +132,24 @@ func TestConfigMapController_isSecretChanged(t *testing.T) {
 	secretChanged, _ = r.isSecretChanged(nsxSecret, nil)
 	assert.True(t, secretChanged)
 
-	// Secret equal case
+	// Secret equal case, with missing key
 	secretChanged, _ = r.isSecretChanged(nsxSecret, lbSecret)
 	assert.False(t, secretChanged)
-
-	// Secret not equal case
+	// Secret equal, with empty key
 	mockSecret := &corev1.Secret{
+		Data: map[string][]byte{"tls.crt": mockValue, "tls.key": mockValue, "tls.ca": []byte{}},
+	}
+	secretChanged, _ = r.isSecretChanged(nsxSecret, mockSecret)
+	assert.False(t, secretChanged)
+	// Secret not equal case, with missing key
+	mockSecret = &corev1.Secret{
 		Data: map[string][]byte{"tls.crt": mockValue, "tls.key": []byte("key")},
+	}
+	secretChanged, _ = r.isSecretChanged(nsxSecret, mockSecret)
+	assert.True(t, secretChanged)
+	// Secret not equal, with all keys
+	mockSecret = &corev1.Secret{
+		Data: map[string][]byte{"tls.crt": mockValue, "tls.key": []byte("key"), "tls.ca": mockValue},
 	}
 	secretChanged, _ = r.isSecretChanged(nsxSecret, mockSecret)
 	assert.True(t, secretChanged)


### PR DESCRIPTION
Improve logic for comparing keys in the secret in order to avoid
conditions where empty and missing tls keys (eg.: tls.ca) are interpreted
as differences in the secret.

Also, do not use DeepEqual as there is only need for comparing tls data
in the secret. This will avoid unnecessarily restarting ncp for unrelated
operator secret changes.

Finally do not include tls.ca in the projected volume if not specified in
the operator secret, or empty.

This commit also adds unit tests for secret comparison cases not
previously covered