### PR TITLE
Add flag to change metrics bind address

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -28,9 +28,12 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 var log = logf.Log.WithName("cmd")
+
+var metricsBindAddress string
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
@@ -47,6 +50,7 @@ func main() {
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
+	pflag.StringVar(&metricsBindAddress, "metrics-bind-address", metrics.DefaultBindAddress, "Sets the metrics bind address (default :8080)")
 
 	pflag.Parse()
 
@@ -78,7 +82,8 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		Namespace: namespace,
+		Namespace:          namespace,
+		MetricsBindAddress: metricsBindAddress,
 	}
 
 	if namespace != "" && namespace != operatortypes.NsxNamespace {


### PR DESCRIPTION
I have a port conflict when running the operator with host networking enabled. I've created this pull request to allow changing the metrics bind port.

```
{"level":"info","ts":"2021-05-12T12:21:26.836Z","logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":"2021-05-12T12:21:29.307Z","logger":"leader","msg":"Found existing lock with my name. I was likely restarted."}
{"level":"info","ts":"2021-05-12T12:21:29.307Z","logger":"leader","msg":"Continuing as the leader."}
{"level":"info","ts":"2021-05-12T12:21:31.767Z","logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
{"level":"error","ts":"2021-05-12T12:21:31.768Z","logger":"controller-runtime.metrics","msg":"metrics server failed to listen. You may want to disable the metrics server or use another port if it is due to conflicts","error":"error listening on :8080: listen tcp :8080: bind: address already in use","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/runner/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nsigs.k8s.io/controller-runtime/pkg/metrics.NewListener\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/metrics/listener.go:48\nsigs.k8s.io/controller-runtime/pkg/manager.New\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.5.2/pkg/manager/manager.go:280\nmain.main\n\t/home/runner/work/nsx-container-plugin-operator/nsx-container-plugin-operator/cmd/manager/main.go:110\nruntime.main\n\t/opt/hostedtoolcache/go/1.13.15/x64/src/runtime/proc.go:203"}
{"level":"error","ts":"2021-05-12T12:21:31.768Z","logger":"cmd","msg":"","error":"error listening on :8080: listen tcp :8080: bind: address already in use","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/runner/go/pkg/mod/github.com/go-logr/zapr@v0.1.1/zapr.go:128\nmain.main\n\t/home/runner/work/nsx-container-plugin-operator/nsx-container-plugin-operator/cmd/manager/main.go:112\nruntime.main\n\t/opt/hostedtoolcache/go/1.13.15/x64/src/runtime/proc.go:203"}
```