### PR TITLE
Change crd version in deployment file

### DIFF
--- a/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ncpinstalls.operator.nsx.vmware.com
@@ -10,66 +10,66 @@ spec:
     plural: ncpinstalls
     singular: ncpinstall
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: NcpInstall is the Schema for the ncpinstalls API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: NcpInstallSpec defines the desired state of NcpInstall
-          type: object
-          properties:
-            ncpReplicas:
-              description: the replica numbers of nsx-ncp deployment
-              type: integer
-              format: int32
-              minimum: 1
-            addNodeTag:
-              description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
-              type: boolean
-        status:
-          description: NcpInstallStatus defines the observed state of NcpInstall
-          type: object
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their status
-              type: array
-              items:
-                description: It is just the standard condition fields
-                type: object
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transit from one status to another
-                    type: string
-                    format: date-time
-                  type:
-                    description: Type of condition
-                    type: string
-                  status:
-                    description: Status of condition, one of 'True', 'False', 'Unknown'
-                    type: string
-                  reason:
-                    description: Brief reason for the condition
-                    type: string
-                  message:
-                    description: Human readable message indicating details
-                    type: string
-      type: object
-  version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: NcpInstall is the Schema for the ncpinstalls API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NcpInstallSpec defines the desired state of NcpInstall
+            type: object
+            properties:
+              ncpReplicas:
+                description: the replica numbers of nsx-ncp deployment
+                type: integer
+                format: int32
+                minimum: 1
+              addNodeTag:
+                description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
+                type: boolean
+          status:
+            description: NcpInstallStatus defines the observed state of NcpInstall
+            type: object
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                type: array
+                items:
+                  description: It is just the standard condition fields
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status to another
+                      type: string
+                      format: date-time
+                    type:
+                      description: Type of condition
+                      type: string
+                    status:
+                      description: Status of condition, one of 'True', 'False', 'Unknown'
+                      type: string
+                    reason:
+                      description: Brief reason for the condition
+                      type: string
+                    message:
+                      description: Human readable message indicating details
+                      type: string
+

--- a/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ncpinstalls.operator.nsx.vmware.com
@@ -10,66 +10,66 @@ spec:
     plural: ncpinstalls
     singular: ncpinstall
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: NcpInstall is the Schema for the ncpinstalls API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: NcpInstallSpec defines the desired state of NcpInstall
-          type: object
-          properties:
-            ncpReplicas:
-              description: the replica numbers of nsx-ncp deployment
-              type: integer
-              format: int32
-              minimum: 1
-            addNodeTag:
-              description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
-              type: boolean
-        status:
-          description: NcpInstallStatus defines the observed state of NcpInstall
-          type: object
-          properties:
-            conditions:
-              description: conditions is a list of conditions and their status
-              type: array
-              items:
-                description: It is just the standard condition fields
-                type: object
-                properties:
-                  lastTransitionTime:
-                    description: Last time the condition transit from one status to another
-                    type: string
-                    format: date-time
-                  type:
-                    description: Type of condition
-                    type: string
-                  status:
-                    description: Status of condition, one of 'True', 'False', 'Unknown'
-                    type: string
-                  reason:
-                    description: Brief reason for the condition
-                    type: string
-                  message:
-                    description: Human readable message indicating details
-                    type: string
-      type: object
-  version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        type: object
+        description: NcpInstall is the Schema for the ncpinstalls API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: NcpInstallSpec defines the desired state of NcpInstall
+            type: object
+            properties:
+              ncpReplicas:
+                description: the replica numbers of nsx-ncp deployment
+                type: integer
+                format: int32
+                minimum: 1
+              addNodeTag:
+                description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
+                type: boolean
+          status:
+            description: NcpInstallStatus defines the observed state of NcpInstall
+            type: object
+            properties:
+              conditions:
+                description: conditions is a list of conditions and their status
+                type: array
+                items:
+                  description: It is just the standard condition fields
+                  type: object
+                  properties:
+                    lastTransitionTime:
+                      description: Last time the condition transit from one status to another
+                      type: string
+                      format: date-time
+                    type:
+                      description: Type of condition
+                      type: string
+                    status:
+                      description: Status of condition, one of 'True', 'False', 'Unknown'
+                      type: string
+                    reason:
+                      description: Brief reason for the condition
+                      type: string
+                    message:
+                      description: Human readable message indicating details
+                      type: string
+


### PR DESCRIPTION
Change crd version from apiextensions.k8s.io/v1beta1 to
apiextensions.k8s.io/v1, as v1beta1 is deprecated in k8s 1.16 and
removed in k8s 1.22