### PR TITLE
Remove force wait_for_security_policy_sync True

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -80,7 +80,6 @@ func (adaptor *ConfigMapOc) FillDefaults(configmap *corev1.ConfigMap, spec *conf
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "coe", "adaptor", "openshift4", true))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_v3", "policy_nsxapi", "True", true))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_v3", "single_tier_topology", "True", true))
-	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_v3", "wait_for_security_policy_sync", "True", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "coe", "enable_snat", "True", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "ha", "enable", "True", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "k8s", "process_oc_network", "False", true))


### PR DESCRIPTION
Remove force configmap option wait_for_security_policy_sync as true
to use NCP upstream configmap default value