### PR TITLE
Switch to v1 CRD

### DIFF
--- a/bundle/kubernetes/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/bundle/kubernetes/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ncpinstalls.operator.nsx.vmware.com

--- a/bundle/openshift4/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/bundle/openshift4/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ncpinstalls.operator.nsx.vmware.com


### PR DESCRIPTION
v1beta1 CRD is not available anymore in K8S APIs starting
with K8S 1.22.