### PR TITLE
Revert OC manifest by removing process_oc_network

### DIFF
--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -187,6 +187,9 @@ rules:
    - extensions
    - networking.k8s.io
    - apps
+
+   - config.openshift.io
+
    resources:
      - deployments
      - endpoints
@@ -202,6 +205,10 @@ rules:
 
 
      - routes
+
+
+     - network
+     - networks
 
    verbs:
      - get
@@ -306,7 +313,12 @@ rules:
 
 
 
-
+ - apiGroups:
+   - config.openshift.io
+   resources:
+     - networks
+   verbs:
+     - patch
  - apiGroups:
    - route.openshift.io
    resources:


### PR DESCRIPTION
Revert openshift4 manifest yaml changs caused by
removing process_oc_network code patch

This change will only impact 3.2.0 release branch, so we only want to merge this change to upstream 3.2.0 branch.