### PR TITLE
Set node-agent-pod deletion grace period to 60 seconds

### DIFF
--- a/pkg/controller/pod/pod_controller.go
+++ b/pkg/controller/pod/pod_controller.go
@@ -393,7 +393,7 @@ func deletePods(pods []corev1.Pod, c client.Client) bool {
 	allPodsDeleted := true
 	for _, pod := range pods {
 		err := c.Delete(
-			context.TODO(), &pod, client.GracePeriodSeconds(5),
+			context.TODO(), &pod, client.GracePeriodSeconds(60),
 			client.PropagationPolicy(policy))
 		if err != nil {
 			log.Error(err, fmt.Sprintf("Unable to delete pod %v. Its "+


### PR DESCRIPTION
5 seconds deletion grace period is not enough for nsx-ovs to gracefully
terminate as it (de)activates Network Manager connection profiles.