### PR TITLE
Add Ncp NodeSelector from NcpInstall CRD

### DIFF
--- a/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -45,6 +45,14 @@ spec:
               addNodeTag:
                 description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
                 type: boolean
+              nsx-ncp:
+                description: nsx-ncp defines what properties users can configure for NCP Deployment
+                type: object
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
           status:
             description: NcpInstallStatus defines the observed state of NcpInstall
             type: object

--- a/deploy/kubernetes/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
@@ -6,3 +6,7 @@ metadata:
 spec:
   ncpReplicas: 1
   addNodeTag: false
+  nsx-ncp:
+    # Uncomment below to add specific nodeSelector for nsx-ncp component
+    #nodeSelector:
+      #<node_label_key>: <node_label_value>

--- a/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -45,6 +45,14 @@ spec:
               addNodeTag:
                 description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
                 type: boolean
+              nsx-ncp:
+                description: nsx-ncp defines what properties users can configure for NCP Deployment
+                type: object
+                properties:
+                  nodeSelector:
+                    additionalProperties:
+                      type: string
+                    type: object
           status:
             description: NcpInstallStatus defines the observed state of NcpInstall
             type: object

--- a/deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
@@ -6,3 +6,7 @@ metadata:
 spec:
   ncpReplicas: 1
   addNodeTag: true
+  nsx-ncp:
+    # Uncomment below to add specific nodeSelector for nsx-ncp component
+    #nodeSelector:
+      #<node_label_key>: <node_label_value>

--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -735,6 +735,10 @@ spec:
                   values:
                   - nsx-networking
               topologyKey: "kubernetes.io/hostname"
+      
+      # nodeSelector is configured by operator ncp-install CRD
+      nodeSelector:
+        {{ .NcpNodeSelector }}
 
       containers:
         - name: nsx-ncp

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -736,6 +736,10 @@ spec:
                   - nsx-networking
               topologyKey: "kubernetes.io/hostname"
 
+      # nodeSelector is configured by operator ncp-install CRD
+      nodeSelector:
+        {{ .NcpNodeSelector }}
+
       containers:
         - name: nsx-ncp
           # Docker image for NCP

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -522,6 +522,10 @@ spec:
                   values:
                   - nsx-networking
               topologyKey: "kubernetes.io/hostname"
+      
+      # nodeSelector is configured by operator ncp-install CRD
+      nodeSelector:
+        {{ .NcpNodeSelector }}
 
       containers:
         - name: nsx-ncp

--- a/pkg/apis/operator/v1/ncpinstall_types.go
+++ b/pkg/apis/operator/v1/ncpinstall_types.go
@@ -20,6 +20,13 @@ type NcpInstallSpec struct {
 	NcpReplicas int32 `json:"ncpReplicas,omitempty"`
 	// For tagging node logical switch ports with node name and cluster
 	AddNodeTag bool `json:"addNodeTag,omitempty"`
+	// For configuring nsx-ncp Deployment properties
+	NsxNcpSpec NsxNcpDeploymentSpec `json:"nsx-ncp,omitempty"`
+}
+
+// NsxNcpDeploymentSpec define user configured properties for NCP Deployment
+type NsxNcpDeploymentSpec struct {
+	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 }
 
 // NcpInstallStatus defines the observed state of NcpInstall

--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -211,8 +211,9 @@ func TestRender(t *testing.T) {
 	var nsxSecret *corev1.Secret
 	var lbSecret *corev1.Secret
 	var ncpReplicas int32 = 1
+	var ncpNodeSelector *map[string]string
 
-	objs, err := Render(mockConfigMap, &ncpReplicas, nsxSecret, lbSecret)
+	objs, err := Render(mockConfigMap, &ncpReplicas, ncpNodeSelector, nsxSecret, lbSecret)
 	assert.Empty(t, objs)
 	assert.Error(t, err, "failed to render manifests")
 }

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -19,6 +19,7 @@ const (
 	NodeAgentConfigMapRenderKey  string         = "NSXNodeAgentConfig"
 	NcpImageKey                  string         = "NcpImage"
 	NcpReplicasKey               string         = "NcpReplicas"
+	NcpNodeSelectorRenderKey     string         = "NcpNodeSelector"
 	NsxNodeAgentDsName           string         = "nsx-node-agent"
 	NsxNcpBootstrapDsName        string         = "nsx-ncp-bootstrap"
 	NsxNcpDeploymentName         string         = "nsx-ncp"


### PR DESCRIPTION
This patch is to allow user to configure NodeSelector for NCP Deployment
by editing operator.nsx.vmware.com_v1_ncpinstall_cr.yaml spec field:
For example, user can add nodeSelector: disktype: ssd to make NCP pod to be
deployed in the node labeled with disktype: ssd. Operator dynamically detects
user-defined spec changes to sync with NCP Deployment once user make changes.

One example for NCP nodeSelector
spec:
  nsx-ncp:
    nodeSelector:
      disktype: ssd
     
Resolves issue #54