### PR TITLE
Set default coe adaptor for k8s env

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -56,6 +56,7 @@ func (adaptor *ConfigMapK8s) FillDefaults(configmap *corev1.ConfigMap, spec *con
 		log.Error(err, "failed to load ConfigMap")
 		return err
 	}
+	appendErrorIfNotNil(&errs, fillDefault(cfg, "coe", "adaptor", "kubernetes", true))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "coe", "enable_snat", "True", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "ha", "enable", "True", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "mtu", strconv.Itoa(operatortypes.DefaultMTU), false))


### PR DESCRIPTION
Since Container orchestrator adaptor option in configmap:
 'adaptor = kubernetes'
 is hidden, so it's needed to set default value 'kubernetes' 
of configmap in the code for k8s env.
