### PR TITLE
Doc that flag "addNodeTag" should be disabled for node multiple NICs

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Set container network CIDRs `clusterNetwork` in `$MY_CLUSTER/install-config.yaml
 ```
 $ openshift-install --dir=$MY_CLUSTER create manifests
 ```
+
+If one cluster node has multiple VirtualNetworkInterfaces, the operator cannot
+detect which interface should be enabled as the containers' parent interface,
+so the user should edit `deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml`
+to set `addNodeTag: false` and manually tag the target node port by
+`scope=ncp/node_name, tag=<node_name>` and `scope=ncp/node_name, tag=<cluster_name>`
+on NSX-T.
+
 Put operator yaml files from `deploy/openshift4/` to `$MY_CLUSTER/manifests`,
 edit configmap.yaml about operator configurations, add the operator image and
 NCP image in operator.yaml.

--- a/bundle/kubernetes/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/bundle/kubernetes/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -43,7 +43,8 @@ spec:
                 format: int32
                 minimum: 1
               addNodeTag:
-                description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
+                description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
+                  Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'
                 type: boolean
           status:
             description: NcpInstallStatus defines the observed state of NcpInstall

--- a/bundle/openshift4/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/bundle/openshift4/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -43,7 +43,8 @@ spec:
                 format: int32
                 minimum: 1
               addNodeTag:
-                description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
+                description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
+                  Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'
                 type: boolean
           status:
             description: NcpInstallStatus defines the observed state of NcpInstall

--- a/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -43,7 +43,8 @@ spec:
                 format: int32
                 minimum: 1
               addNodeTag:
-                description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
+                description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
+                  Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'
                 type: boolean
               nsx-ncp:
                 description: nsx-ncp defines what properties users can configure for NCP Deployment

--- a/deploy/kubernetes/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: nsx-system-operator
 spec:
   ncpReplicas: 1
+  # Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should not be set to true
   addNodeTag: false
   nsx-ncp:
     # Uncomment below to add user-defined nodeSelector for NCP Deployment

--- a/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -43,7 +43,8 @@ spec:
                 format: int32
                 minimum: 1
               addNodeTag:
-                description: Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false
+                description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
+                  Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'
                 type: boolean
               nsx-ncp:
                 description: nsx-ncp defines what properties users can configure for NCP Deployment

--- a/deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: nsx-system-operator
 spec:
   ncpReplicas: 1
+  # Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false
   addNodeTag: true
   nsx-ncp:
     # Uncomment below to add user-defined nodeSelector for NCP Deployment

--- a/pkg/apis/operator/v1/ncpinstall_types.go
+++ b/pkg/apis/operator/v1/ncpinstall_types.go
@@ -20,6 +20,7 @@ type NcpInstallSpec struct {
 	// +optional
 	NcpReplicas int32 `json:"ncpReplicas,omitempty"`
 	// For tagging node logical switch ports with node name and cluster
+	// Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.
 	AddNodeTag bool `json:"addNodeTag,omitempty"`
 	// For configuring nsx-ncp Deployment properties
 	NsxNcpSpec NsxNcpDeploymentSpec `json:"nsx-ncp,omitempty"`


### PR DESCRIPTION
If a node has multiple VirtualNetworkInterfaces attached, the operator
cannot detect which node LSP should be enabled. So the customer should
disable flag "addNodeTag" and tag the node LSP by manually.