### PR TITLE
Add a command flag to metrics server bindaddress

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -44,6 +44,11 @@ func main() {
 	// be added before calling pflag.Parse().
 	pflag.CommandLine.AddFlagSet(zap.FlagSet())
 
+	// metricsBindAddr is the TCP address that the controller should bind to
+	// for serving prometheus metrics.
+	var metricsBindAddr string
+	flag.StringVar(&metricsBindAddr, "metrics-server-bind-address", ":8181", "The address the prometheus metrics server binds to.")
+
 	// Add flags registered by imported packages (e.g. glog and
 	// controller-runtime)
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
@@ -78,7 +83,8 @@ func main() {
 
 	// Set default manager options
 	options := manager.Options{
-		Namespace: namespace,
+		Namespace:          namespace,
+		MetricsBindAddress: metricsBindAddr,
 	}
 
 	if namespace != "" && namespace != operatortypes.NsxNamespace {

--- a/deploy/kubernetes/operator.yaml
+++ b/deploy/kubernetes/operator.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: nsx-ncp-operator
           image: docker.io/vmware/nsx-container-plugin-operator
-          command: ["/bin/bash", "-c", "nsx-ncp-operator --zap-time-encoding=iso8601"]
+          command: ["/bin/bash", "-c", "nsx-ncp-operator --zap-time-encoding=iso8601 --metrics-server-bind-address=:8181"]
           volumeMounts:
           - {mountPath: /host/etc/os-release, name: host-os-release}
           imagePullPolicy: IfNotPresent

--- a/deploy/openshift4/operator.yaml
+++ b/deploy/openshift4/operator.yaml
@@ -28,7 +28,7 @@ spec:
       containers:
         - name: nsx-ncp-operator
           image: docker.io/vmware/nsx-container-plugin-operator
-          command: ["/bin/bash", "-c", "nsx-ncp-operator --zap-time-encoding=iso8601"]
+          command: ["/bin/bash", "-c", "nsx-ncp-operator --zap-time-encoding=iso8601 --metrics-server-bind-address=:8181"]
           volumeMounts:
           - {mountPath: /host/etc/os-release, name: host-os-release}
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
This patch is to add a command flag for metrics server bindaddress
to make it as a configurable option by users

By default, metrics server is listening to bindaddress at :8080 port, which
could conflict with some user's env settings.
Hence, this patch adds a command flag: metrics-server-bind-address,
whose default value is 8181. User can also change this value from
command line flags as necessary to avoid conflicts with user's env