### PR TITLE
Add NodeName Env in nsx-kube-proxy Container

### DIFF
--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -1203,6 +1203,11 @@ spec:
                   fieldPath: metadata.name
             - name: CONTAINER_NAME
               value: nsx-kube-proxy
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           livenessProbe:
             exec:
               command:

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -1207,6 +1207,11 @@ spec:
                   fieldPath: metadata.name
             - name: CONTAINER_NAME
               value: nsx-kube-proxy
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           livenessProbe:
             exec:
               command:

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -1000,6 +1000,11 @@ spec:
                   fieldPath: metadata.name
             - name: CONTAINER_NAME
               value: nsx-kube-proxy
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
This patch is to sync ncp manifest change which adds a NodeName Env
in nsx-kube-proxy so that kube-proxy can get container's nodename.