### PR TITLE
Uncomment volumes when use nsx-ovs kernel module

### DIFF
--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -950,20 +950,37 @@ spec:
             mountPath: /var/run/openvswitch
             subPath: openvswitch
           # Uncomment these mounts if installing NSX-OVS kernel module
-        #   # mount host lib modules to install OVS kernel module if needed
-        #   - name: host-modules
-        #     mountPath: /lib/modules
-        #   # mount openvswitch database
-        #   - name: host-config-openvswitch
-        #     mountPath: /etc/openvswitch
-        #   - name: dir-tmp-usr-ovs-kmod-backup
-        #   # we move the usr kmod files to this dir temporarily before
-        #   # installing new OVS kmod and/or backing up existing OVS kmod backup
-        #     mountPath: /tmp/nsx_usr_ovs_kmod_backup
+{{if .UseNsxOvsKmod}}
+          # mount host lib modules to install OVS kernel module if needed
+          - name: host-modules
+            mountPath: /lib/modules
+          # mount openvswitch database
+          - name: host-config-openvswitch
+            mountPath: /etc/openvswitch
+          - name: dir-tmp-usr-ovs-kmod-backup
+          # we move the usr kmod files to this dir temporarily before
+          # installing new OVS kmod and/or backing up existing OVS kmod backup
+            mountPath: /tmp/nsx_usr_ovs_kmod_backup
 
-        #   # mount linux headers for compiling OVS kmod
-        #   - name: host-usr-src
-        #     mountPath: /usr/src
+          # mount linux headers for compiling OVS kmod
+          - name: host-usr-src
+            mountPath: /usr/src
+{{else}}
+          # # mount host lib modules to install OVS kernel module if needed
+          # - name: host-modules
+          #   mountPath: /lib/modules
+          # # mount openvswitch database
+          # - name: host-config-openvswitch
+          #   mountPath: /etc/openvswitch
+          # - name: dir-tmp-usr-ovs-kmod-backup
+          # # we move the usr kmod files to this dir temporarily before
+          # # installing new OVS kmod and/or backing up existing OVS kmod backup
+          #   mountPath: /tmp/nsx_usr_ovs_kmod_backup
+
+          # # mount linux headers for compiling OVS kmod
+          # - name: host-usr-src
+          #   mountPath: /usr/src
+{{end}}
           # mount apparmor files to load the node-agent-apparmor
           - name: app-armor-cache
             mountPath: /var/cache/apparmor

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -395,6 +395,12 @@ func Render(configmap *corev1.ConfigMap, ncpReplicas *int32, ncpNodeSelector *ma
 		renderData.Data[operatortypes.NsxKeyRenderKey] = ""
 		renderData.Data[operatortypes.NsxCARenderKey] = ""
 	}
+	// Set value of use_nsx_ovs_kernel_module
+	if cfg.Section("nsx_node_agent").Key("use_nsx_ovs_kernel_module").Value() == "True" {
+		renderData.Data[operatortypes.UseNsxOvsKernelModule] = true
+	} else {
+		renderData.Data[operatortypes.UseNsxOvsKernelModule] = false
+	}
 	manifestDir, err := GetManifestDir()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifestDir")

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -39,7 +39,7 @@ const (
 	NsxCATempPath                string         = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName    string         = "nsx-node-agent"
 	OsReleaseFile                string         = "/host/etc/os-release"
-	UseNsxOvsKernelModule		 string			= "UseNsxOvsKmod"
+	UseNsxOvsKernelModule        string         = "UseNsxOvsKmod"
 	TimeBeforeRecoverNetwork     time.Duration  = 180 * time.Second
 	DefaultResyncPeriod          time.Duration  = 2 * time.Minute
 )

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -39,6 +39,7 @@ const (
 	NsxCATempPath                string         = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName    string         = "nsx-node-agent"
 	OsReleaseFile                string         = "/host/etc/os-release"
+	UseNsxOvsKernelModule		 string			= "UseNsxOvsKmod"
 	TimeBeforeRecoverNetwork     time.Duration  = 180 * time.Second
 	DefaultResyncPeriod          time.Duration  = 2 * time.Minute
 )


### PR DESCRIPTION
When use nsx-ovs kernel module, we need to uncomment the volume mounts
for installing nsx-ovs kernel module, otherwise nsx-ncp-bootstrap will
fail to start.