### PR TITLE
Uncomment volumes when use nsx-ovs kernel module

### DIFF
--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -950,6 +950,27 @@ spec:
           - name: host-var-run
             mountPath: /var/run/openvswitch
             subPath: openvswitch
+{{if .UseNsxOvsKmod}}
+          # mount host lib modules to install OVS kernel module if needed
+          - name: host-modules
+            mountPath: /lib/modules
+          # mount openvswitch database
+          - name: host-config-openvswitch
+            mountPath: /etc/openvswitch
+          - name: dir-tmp-usr-ovs-kmod-backup
+          # we move the usr kmod files to this dir temporarily before
+          # installing new OVS kmod and/or backing up existing OVS kmod backup
+            mountPath: /tmp/nsx_usr_ovs_kmod_backup
+
+
+          # mount to which an OVS kmod file is copied.
+          - name: host-usr-share
+            mountPath: /host/usr/share
+          # mount host's depmod to create module dependencies after creating
+          # new OVS kmod files
+          - name: host-depmod
+            mountPath: /sbin/depmod
+{{else}}
           # Uncomment these mounts if installing NSX-OVS kernel module
         #   # mount host lib modules to install OVS kernel module if needed
         #   - name: host-modules
@@ -970,6 +991,7 @@ spec:
         #   # new OVS kmod files
         #   - name: host-depmod
         #     mountPath: /sbin/depmod
+{{end}}
           # mount host's rpm package database to remove nsx-cni if installed
           - name: rpm-lib
             mountPath: /var/lib/rpm
@@ -1038,6 +1060,25 @@ spec:
         - name: host-var-run
           hostPath:
             path: /var/run
+{{if .UseNsxOvsKmod}}
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/openvswitch
+        - name: dir-tmp-usr-ovs-kmod-backup
+          hostPath:
+            path: /tmp/nsx_usr_ovs_kmod_backup
+
+
+        - name: host-usr-share
+          hostPath:
+            path: /usr/share
+        - name: host-depmod
+          hostPath:
+            path: /sbin/depmod
+{{else}}
         # Uncomment these volumes if installing NSX-OVS kernel module
         # - name: host-modules
         #   hostPath:
@@ -1056,6 +1097,7 @@ spec:
         # - name: host-depmod
         #   hostPath:
         #     path: /sbin/depmod
+{{end}}
         - name: rpm-lib
           hostPath:
             path: /var/lib/rpm

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -949,7 +949,6 @@ spec:
           - name: host-var-run
             mountPath: /var/run/openvswitch
             subPath: openvswitch
-          # Uncomment these mounts if installing NSX-OVS kernel module
 {{if .UseNsxOvsKmod}}
           # mount host lib modules to install OVS kernel module if needed
           - name: host-modules
@@ -966,6 +965,7 @@ spec:
           - name: host-usr-src
             mountPath: /usr/src
 {{else}}
+          # Uncomment these mounts if installing NSX-OVS kernel module
           # # mount host lib modules to install OVS kernel module if needed
           # - name: host-modules
           #   mountPath: /lib/modules

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -950,20 +950,37 @@ spec:
             mountPath: /var/run/openvswitch
             subPath: openvswitch
           # Uncomment these mounts if installing NSX-OVS kernel module
-        #   # mount host lib modules to install OVS kernel module if needed
-        #   - name: host-modules
-        #     mountPath: /lib/modules
-        #   # mount openvswitch database
-        #   - name: host-config-openvswitch
-        #     mountPath: /etc/openvswitch
-        #   - name: dir-tmp-usr-ovs-kmod-backup
-        #   # we move the usr kmod files to this dir temporarily before
-        #   # installing new OVS kmod and/or backing up existing OVS kmod backup
-        #     mountPath: /tmp/nsx_usr_ovs_kmod_backup
+{{if .UseNsxOvsKmod}}
+          # mount host lib modules to install OVS kernel module if needed
+          - name: host-modules
+            mountPath: /lib/modules
+          # mount openvswitch database
+          - name: host-config-openvswitch
+            mountPath: /etc/openvswitch
+          - name: dir-tmp-usr-ovs-kmod-backup
+          # we move the usr kmod files to this dir temporarily before
+          # installing new OVS kmod and/or backing up existing OVS kmod backup
+            mountPath: /tmp/nsx_usr_ovs_kmod_backup
 
-        #   # mount linux headers for compiling OVS kmod
-        #   - name: host-usr-src
-        #     mountPath: /usr/src
+          # mount linux headers for compiling OVS kmod
+          - name: host-usr-src
+            mountPath: /usr/src
+{{else}}
+          # # mount host lib modules to install OVS kernel module if needed
+          # - name: host-modules
+          #   mountPath: /lib/modules
+          # # mount openvswitch database
+          # - name: host-config-openvswitch
+          #   mountPath: /etc/openvswitch
+          # - name: dir-tmp-usr-ovs-kmod-backup
+          # # we move the usr kmod files to this dir temporarily before
+          # # installing new OVS kmod and/or backing up existing OVS kmod backup
+          #   mountPath: /tmp/nsx_usr_ovs_kmod_backup
+
+          # # mount linux headers for compiling OVS kmod
+          # - name: host-usr-src
+          #   mountPath: /usr/src
+{{end}}
           # mount apparmor files to load the node-agent-apparmor
           - name: app-armor-cache
             mountPath: /var/cache/apparmor

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -966,20 +966,20 @@ spec:
             mountPath: /usr/src
 {{else}}
           # Uncomment these mounts if installing NSX-OVS kernel module
-          # # mount host lib modules to install OVS kernel module if needed
-          # - name: host-modules
-          #   mountPath: /lib/modules
-          # # mount openvswitch database
-          # - name: host-config-openvswitch
-          #   mountPath: /etc/openvswitch
-          # - name: dir-tmp-usr-ovs-kmod-backup
-          # # we move the usr kmod files to this dir temporarily before
-          # # installing new OVS kmod and/or backing up existing OVS kmod backup
-          #   mountPath: /tmp/nsx_usr_ovs_kmod_backup
+        #   # mount host lib modules to install OVS kernel module if needed
+        #   - name: host-modules
+        #     mountPath: /lib/modules
+        #   # mount openvswitch database
+        #   - name: host-config-openvswitch
+        #     mountPath: /etc/openvswitch
+        #   - name: dir-tmp-usr-ovs-kmod-backup
+        #   # we move the usr kmod files to this dir temporarily before
+        #   # installing new OVS kmod and/or backing up existing OVS kmod backup
+        #     mountPath: /tmp/nsx_usr_ovs_kmod_backup
 
-          # # mount linux headers for compiling OVS kmod
-          # - name: host-usr-src
-          #   mountPath: /usr/src
+        #   # mount linux headers for compiling OVS kmod
+        #   - name: host-usr-src
+        #     mountPath: /usr/src
 {{end}}
           # mount apparmor files to load the node-agent-apparmor
           - name: app-armor-cache

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -1054,6 +1054,21 @@ spec:
         - name: host-var-run
           hostPath:
             path: /var/run
+{{if .UseNsxOvsKmod}}
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/openvswitch
+        - name: dir-tmp-usr-ovs-kmod-backup
+          hostPath:
+            path: /tmp/nsx_usr_ovs_kmod_backup
+
+        - name: host-usr-src
+          hostPath:
+            path: /usr/src
+{{else}}
         # Uncomment these volumes if installing NSX-OVS kernel module
         # - name: host-modules
         #   hostPath:
@@ -1068,6 +1083,7 @@ spec:
         # - name: host-usr-src
         #   hostPath:
         #     path: /usr/src
+{{end}}
         - name: app-armor-cache
           hostPath:
             path: /var/cache/apparmor

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -734,6 +734,27 @@ spec:
           - name: host-var-run
             mountPath: /var/run/openvswitch
             subPath: openvswitch
+{{if .UseNsxOvsKmod}}
+          # mount host lib modules to install OVS kernel module if needed
+          - name: host-modules
+            mountPath: /lib/modules
+          # mount openvswitch database
+          - name: host-config-openvswitch
+            mountPath: /etc/openvswitch
+          - name: dir-tmp-usr-ovs-kmod-backup
+          # we move the usr kmod files to this dir temporarily before
+          # installing new OVS kmod and/or backing up existing OVS kmod backup
+            mountPath: /tmp/nsx_usr_ovs_kmod_backup
+
+
+          # mount to which an OVS kmod file is copied.
+          - name: host-usr-share
+            mountPath: /host/usr/share
+          # mount host's depmod to create module dependencies after creating
+          # new OVS kmod files
+          - name: host-depmod
+            mountPath: /sbin/depmod
+{{else}}
           # Uncomment these mounts if installing NSX-OVS kernel module
         #   # mount host lib modules to install OVS kernel module if needed
         #   - name: host-modules
@@ -754,6 +775,7 @@ spec:
         #   # new OVS kmod files
         #   - name: host-depmod
         #     mountPath: /sbin/depmod
+{{end}}
           # mount host's rpm package database to remove nsx-cni if installed
           - name: rpm-lib
             mountPath: /var/lib/rpm
@@ -829,6 +851,25 @@ spec:
         - name: host-var-run
           hostPath:
             path: /var/run
+{{if .UseNsxOvsKmod}}
+        - name: host-modules
+          hostPath:
+            path: /lib/modules
+        - name: host-config-openvswitch
+          hostPath:
+            path: /etc/openvswitch
+        - name: dir-tmp-usr-ovs-kmod-backup
+          hostPath:
+            path: /tmp/nsx_usr_ovs_kmod_backup
+
+
+        - name: host-usr-share
+          hostPath:
+            path: /usr/share
+        - name: host-depmod
+          hostPath:
+            path: /sbin/depmod
+{{else}}
         # Uncomment these volumes if installing NSX-OVS kernel module
         # - name: host-modules
         #   hostPath:
@@ -847,6 +888,7 @@ spec:
         # - name: host-depmod
         #   hostPath:
         #     path: /sbin/depmod
+{{end}}
         - name: rpm-lib
           hostPath:
             path: /var/lib/rpm

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -397,9 +397,9 @@ func Render(configmap *corev1.ConfigMap, ncpReplicas *int32, ncpNodeSelector *ma
 	}
 	// Set value of use_nsx_ovs_kernel_module
 	if cfg.Section("nsx_node_agent").Key("use_nsx_ovs_kernel_module").Value() == "True" {
-		renderData.Data[operatortypes.UseNsxOvsKernelModule] = true
+		renderData.Data[operatortypes.NsxOvsKmodRenderKey] = true
 	} else {
-		renderData.Data[operatortypes.UseNsxOvsKernelModule] = false
+		renderData.Data[operatortypes.NsxOvsKmodRenderKey] = false
 	}
 	manifestDir, err := GetManifestDir()
 	if err != nil {

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -395,6 +395,12 @@ func Render(configmap *corev1.ConfigMap, ncpReplicas *int32, ncpNodeSelector *ma
 		renderData.Data[operatortypes.NsxKeyRenderKey] = ""
 		renderData.Data[operatortypes.NsxCARenderKey] = ""
 	}
+	// Set value of use_nsx_ovs_kernel_module
+	if cfg.Section("nsx_node_agent").Key("use_nsx_ovs_kernel_module").Value() == "True" {
+		renderData.Data[operatortypes.UseNsxOvsKernelModule] = true
+	} else {
+		renderData.Data[operatortypes.UseNsxOvsKernelModule] = false
+	}
 	manifestDir, err := GetManifestDir()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get manifestDir")

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -39,7 +39,7 @@ const (
 	NsxCATempPath                string         = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName    string         = "nsx-node-agent"
 	OsReleaseFile                string         = "/host/etc/os-release"
-	UseNsxOvsKernelModule        string         = "UseNsxOvsKmod"
+	NsxOvsKmodRenderKey          string         = "UseNsxOvsKmod"
 	TimeBeforeRecoverNetwork     time.Duration  = 180 * time.Second
 	DefaultResyncPeriod          time.Duration  = 2 * time.Minute
 )

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -39,7 +39,7 @@ const (
 	NsxCATempPath                string         = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName    string         = "nsx-node-agent"
 	OsReleaseFile                string         = "/host/etc/os-release"
-	UseNsxOvsKernelModule		 string			= "UseNsxOvsKmod"
+	UseNsxOvsKernelModule        string         = "UseNsxOvsKmod"
 	TimeBeforeRecoverNetwork     time.Duration  = 180 * time.Second
 	DefaultResyncPeriod          time.Duration  = 2 * time.Minute
 )

--- a/pkg/types/names.go
+++ b/pkg/types/names.go
@@ -39,6 +39,7 @@ const (
 	NsxCATempPath                string         = "/tmp/nsx.ca"
 	NsxNodeAgentContainerName    string         = "nsx-node-agent"
 	OsReleaseFile                string         = "/host/etc/os-release"
+	UseNsxOvsKernelModule		 string			= "UseNsxOvsKmod"
 	TimeBeforeRecoverNetwork     time.Duration  = 180 * time.Second
 	DefaultResyncPeriod          time.Duration  = 2 * time.Minute
 )


### PR DESCRIPTION
When use nsx-ovs kernel module, we need to uncomment the volume mounts
for installing nsx-ovs kernel module, otherwise nsx-ncp-bootstrap will
fail to start.
Issue: bug-2884287