### PR TITLE
Add configmap option diff change log

### DIFF
--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -607,7 +607,7 @@ func patchObjSpecAnnotations(obj *unstructured.Unstructured, component string) e
 		log.Error(err, fmt.Sprintf("Patch Object: %s Spec Template annotations failed", component))
 		return err
 	} else {
-		log.Info(fmt.Sprintf("Update Object: %s Spec Template annotations was successful", component))
+		log.Info(fmt.Sprintf("Patch Object: %s Spec Template annotations were successful", component))
 		return nil
 	}
 }


### PR DESCRIPTION
This patch is to enhance log output when user makes configmap change:
1.Log which section is added into or removed from configmap
2.Log configmap option added/uncommented or removed/commented
3.Log configmap option value change