### PR TITLE
Add toleration for control-plane label

### DIFF
--- a/deploy/kubernetes/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
@@ -8,16 +8,18 @@ spec:
   # Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should not be set to true
   addNodeTag: false
   nsx-ncp:
-    # Uncomment below to add user-defined nodeSelector for NCP Deployment
-    #nodeSelector:
+    nodeSelector:
+      # Uncomment below to add user-defined nodeSelector for NCP Deployment
       #<node_label_key>: <node_label_value>
+
     tolerations:
       # Please don't modify below default tolerations for NCP Deployment
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       - key: node.kubernetes.io/network-unavailable
         effect: NoSchedule
-
       # Uncomment below to add user-defined tolerations for NCP Deployment
       #<toleration_specification>
       
@@ -27,12 +29,13 @@ spec:
       # for nsx-ncp-bootstrap and nsx-node-agent DaemonSet
       - key: node-role.kubernetes.io/master
         effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
+        effect: NoSchedule
       - key: node.kubernetes.io/not-ready
         effect: NoSchedule
       - key: node.kubernetes.io/unreachable
         effect: NoSchedule
       - operator: Exists
         effect: NoExecute
-      
       # Uncomment below to add user-defined tolerations for nsx-ncp-bootstrap and nsx-node-agent DaemonSet
       #<toleration_specification>

--- a/deploy/kubernetes/operator.yaml
+++ b/deploy/kubernetes/operator.yaml
@@ -19,6 +19,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node.kubernetes.io/not-ready
       - effect: NoSchedule
         key: node.kubernetes.io/network-unavailable

--- a/deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_v1_ncpinstall_cr.yaml
@@ -8,12 +8,15 @@ spec:
   # Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false
   addNodeTag: true
   nsx-ncp:
-    # Uncomment below to add user-defined nodeSelector for NCP Deployment
-    #nodeSelector:
+    nodeSelector:
+      # Uncomment below to add user-defined nodeSelector for NCP Deployment
       #<node_label_key>: <node_label_value>
+
     tolerations:
       # Please don't modify below default tolerations for NCP Deployment
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       - key: node.kubernetes.io/network-unavailable
         effect: NoSchedule
@@ -25,6 +28,8 @@ spec:
       # Please don't modify below default tolerations
       # for nsx-ncp-bootstrap and nsx-node-agent DaemonSet
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
       - key: node.kubernetes.io/not-ready
         effect: NoSchedule

--- a/deploy/openshift4/operator.yaml
+++ b/deploy/openshift4/operator.yaml
@@ -19,6 +19,8 @@ spec:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
       - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
         key: node.kubernetes.io/not-ready
       - effect: NoSchedule
         key: node.kubernetes.io/network-unavailable


### PR DESCRIPTION
The node-role.kubernetes.io/master label is deprecated.
Hence, adding node-role.kubernetes.io/control-plane toleration
for NCP, nsx-ncp-bootstrap and nsx-node-agent to deploy
NCP, nsx-ncp-bootstrap and nsx-node-agent on control plane nodes.

Add this toleration for operator deployment as well.

Resolves issue #191