### PR TITLE
Add operator log in support bundle

### DIFF
--- a/deploy/kubernetes/operator.yaml
+++ b/deploy/kubernetes/operator.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: nsx-ncp-operator
   namespace: nsx-system-operator
+  labels:
+    tier: nsx-networking
 spec:
   replicas: 1
   selector:
@@ -12,6 +14,7 @@ spec:
     metadata:
       labels:
         name: nsx-ncp-operator
+        tier: nsx-networking
     spec:
       hostNetwork: true
       serviceAccountName: nsx-ncp-operator

--- a/deploy/openshift4/operator.yaml
+++ b/deploy/openshift4/operator.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: nsx-ncp-operator
   namespace: nsx-system-operator
+  labels:
+    tier: nsx-networking
 spec:
   replicas: 1
   selector:
@@ -12,6 +14,7 @@ spec:
     metadata:
       labels:
         name: nsx-ncp-operator
+        tier: nsx-networking
     spec:
       hostNetwork: true
       serviceAccountName: nsx-ncp-operator


### PR DESCRIPTION
Nsxcli collect pod logs by using "tier: nsx-networking" label
to select matching pod. This patch is to add "tier: nsx-networking"
label in ncp-operator pod deployment yaml definition to make nsxcli
can collect operator log.