### PR TITLE
filter node addresses with type host name

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -502,7 +502,7 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 	var nodeAddresses []string
 	reqLogger.Info("Got the node addresses info", "nodeAddresses", nodeAddressesWithType)
 	for _, address := range nodeAddressesWithType {
-		if !inSlice(address.Address, nodeAddresses) {
+		if address.Type != corev1.NodeHostName && !inSlice(address.Address, nodeAddresses) {
 			nodeAddresses = append(nodeAddresses, address.Address)
 		}
 	}


### PR DESCRIPTION
Filter node addresses with type `Hostname` and only add IP addresses
to array.