### PR TITLE
Ensure the error message can be removed after node removal

### DIFF
--- a/pkg/controller/node/node_controller.go
+++ b/pkg/controller/node/node_controller.go
@@ -497,6 +497,7 @@ func (r *ReconcileNode) Reconcile(request reconcile.Request) (reconcile.Result, 
 		if k8serrors.IsNotFound(err) {
 			reqLogger.Info("Node not found and remove it from cache")
 			delete(cachedNodeSet, nodeName)
+			r.status.SetFromNodes(cachedNodeSet)
 			return reconcile.Result{}, nil
 		}
 		cachedNodeSet[nodeName] = &statusmanager.NodeStatus{


### PR DESCRIPTION
This patch will fix the error in the following case:

There's an error while tagging the node port, the operator reports
the error to cluster operator, then the node is removed from the
cluster. If the error is the last one in the cluster operator, it
cannot be cleaned as expected.