### PR TITLE
Add host folder mounted in node agent manifest yaml

### DIFF
--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -1361,6 +1361,7 @@ spec:
             mountPath: /var/log/nsx-ujo
 
 
+
       volumes:
         - name: projected-volume
           projected:
@@ -1420,6 +1421,7 @@ spec:
         - name: nscripts
           hostPath:
             path: /etc/sysconfig/network-scripts
+
 
 
 

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -1350,6 +1350,7 @@ spec:
             mountPath: /var/log/nsx-ujo
 
 
+
       volumes:
         - name: projected-volume
           projected:
@@ -1396,6 +1397,7 @@ spec:
         - name: host-os-release
           hostPath:
             path: /etc/os-release
+
 
 
 

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -1138,6 +1138,12 @@ spec:
           - name: host-var-log-ujo
             mountPath: /var/log/nsx-ujo
 
+          - name: keepalived-conf-dir
+            mountPath: /etc/keepalived
+          - name: static-pods-manifests-dir
+            mountPath: /etc/kubernetes/manifests
+
+
 
       volumes:
         - name: projected-volume
@@ -1198,6 +1204,14 @@ spec:
         - name: nscripts
           hostPath:
             path: /etc/sysconfig/network-scripts
+
+
+        - name: keepalived-conf-dir
+          hostPath:
+            path: /etc/keepalived
+        - name: static-pods-manifests-dir
+          hostPath:
+            path: /etc/kubernetes/manifests
 
 
 


### PR DESCRIPTION
This patch is to add host folder of keepalived config and Kubernetes static pod manifest directory mounted in the node agent nsx-ovs container for openshift platform.