### PR TITLE
Update build workflow to use main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,10 @@ name: Build image
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build-image:
@@ -21,7 +21,7 @@ jobs:
       - name: Build image
         run: make
       - name: Push images to registry
-        if: ${{ github.repository == 'vmware/nsx-container-plugin-operator' && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.repository == 'vmware/nsx-container-plugin-operator' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
         env:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
This commit changes the 'build image' github action workflow to use the main branch instead of the master branch.