### PR TITLE
Avoid unnecessary nsx-node-agent restarts

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -562,8 +562,7 @@ func NeedApplyChange(currConfig *corev1.ConfigMap, prevConfig *corev1.ConfigMap)
 	diffSecs := []string{}
 	currSecs := currCfg.SectionStrings()
 	for _, name := range currSecs {
-		_, err = prevCfg.GetSection(name)
-		if err != nil {
+		if !hasSection(prevCfg, name) {
 			if len(currCfg.Section(name).KeyStrings()) != 0 {
 				log.Info(fmt.Sprintf("Section [%s] is added into configmap", name))
 				diffSecs = append(diffSecs, name)
@@ -613,8 +612,7 @@ func NeedApplyChange(currConfig *corev1.ConfigMap, prevConfig *corev1.ConfigMap)
 	}
 	prevSecs := prevCfg.SectionStrings()
 	for _, name := range prevSecs {
-		_, err = currCfg.GetSection(name)
-		if err != nil {
+		if !hasSection(currCfg, name) {
 			if len(prevCfg.Section(name).KeyStrings()) != 0 {
 				log.Info(fmt.Sprintf("Section [%s] is removed from configmap", name))
 				diffSecs = append(diffSecs, name)
@@ -627,10 +625,13 @@ func NeedApplyChange(currConfig *corev1.ConfigMap, prevConfig *corev1.ConfigMap)
 		if !needChange.ncp && inSlice(sec, operatortypes.NcpSections) {
 			needChange.ncp = true
 		}
-		if !needChange.agent && inSlice(sec, operatortypes.AgentSections) {
+		if !needChange.agent && inSlice(sec, operatortypes.AgentRestartSections) {
 			needChange.agent = true
 		}
-		if !needChange.bootstrap && inSlice(sec, operatortypes.BootstrapOptions) {
+		if !needChange.agent && checkOptionsChange(operatortypes.AgentRestartOptionKeys, sec, prevCfg, currCfg) {
+			needChange.agent = true
+		}
+		if !needChange.bootstrap && checkOptionsChange(operatortypes.BootstrapRestartOptionKeys, sec, prevCfg, currCfg) {
 			needChange.bootstrap = true
 		}
 		if needChange.ncp && needChange.agent && needChange.bootstrap {
@@ -643,6 +644,26 @@ func NeedApplyChange(currConfig *corev1.ConfigMap, prevConfig *corev1.ConfigMap)
 	}
 
 	return needChange, nil
+}
+
+func checkOptionsChange(options map[string][]string, sec string, prevCfg, currCfg *ini.File) bool {
+	if _, ok := options[sec]; !ok {
+		return false
+	}
+	if hasSection(prevCfg, sec) != hasSection(currCfg, sec) {
+		return true
+	}
+	// We can assert that section `sec` exists in both prevCfg and currCfg here.
+	for _, key := range options[sec] {
+		if prevCfg.Section(sec).HasKey(key) != currCfg.Section(sec).HasKey(key) {
+			return true
+		}
+		if prevCfg.Section(sec).HasKey(key) && currCfg.Section(sec).HasKey(key) &&
+			prevCfg.Section(sec).Key(key).Value() != currCfg.Section(sec).Key(key).Value() {
+			return true
+		}
+	}
+	return false
 }
 
 func immutableFieldChanged(cur, prev *ini.File) bool {
@@ -729,6 +750,11 @@ func GenerateOperatorConfigMap(opConfigmap *corev1.ConfigMap, ncpConfigMap *core
 		return err
 	}
 	return nil
+}
+
+func hasSection(cfg *ini.File, section string) bool {
+	_, err := cfg.GetSection(section)
+	return err == nil
 }
 
 func iniWriteToString(cfg *ini.File) (string, error) {

--- a/pkg/types/defaults.go
+++ b/pkg/types/defaults.go
@@ -10,9 +10,26 @@ const (
 
 var (
 	NcpSections      = []string{"DEFAULT", "ha", "k8s", "coe", "nsx_v3", "vc"}
-	AgentSections    = []string{"DEFAULT", "k8s", "coe", "nsx_node_agent", "nsx_kube_proxy"}
 	OperatorSections = []string{"DEFAULT", "ha", "k8s", "coe", "nsx_v3", "vc", "nsx_node_agent", "nsx_kube_proxy"}
-	BootstrapOptions = []string{"DEFAULT", "nsx_node_agent"}
+	// AgentSections are responsible for rendering nsx-node-agent configmap, while not all keys updates in section `coe` and
+	// `k8s` require restart of nsx-node-agent. So AgentRestartSections are responsible for checking whether nsx-node-agent
+	// should be restarted when related keys are updated.
+	AgentSections              = []string{"DEFAULT", "k8s", "coe", "nsx_node_agent", "nsx_kube_proxy"}
+	AgentRestartSections       = []string{"DEFAULT", "nsx_node_agent", "nsx_kube_proxy"}
+	BootstrapRestartOptionKeys = map[string][]string{
+		"DEFAULT": {
+			"log_dir", "log_file", "log_rotation_file_max_mb", "log_rotation_backup_count",
+		},
+		"nsx_node_agent": {
+			"enable_ipv6", "use_nsx_ovs_kernel_module", "ovs_uplink_port", "mtu",
+		},
+	}
+	AgentRestartOptionKeys = map[string][]string{
+		"k8s": {
+			"apiserver_host_ip", "apiserver_host_port", "client_token_file", "ca_file", "enable_hostport_snat",
+		},
+		"coe": {"connect_retry_timeout"},
+	}
 )
 
 var TASSection = string("cf")


### PR DESCRIPTION
It is not necessary to restart nsx-node-agent when some keys are changed in section `k8s` and `coe`. So update the code to only restart nsx-node-agent when specified keys in section `k8s` and `coe` are changed.