### PR TITLE
Sync manifest change of NCP 4.1.1

### DIFF
--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -764,7 +764,6 @@ spec:
                   - nsx-networking
               topologyKey: "kubernetes.io/hostname"
 
-      priorityClassName: system-cluster-critical
       containers:
         - name: nsx-ncp
           # Docker image for NCP
@@ -794,9 +793,9 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - check_pod_liveness nsx-ncp 5
+                - check_pod_liveness nsx-ncp 30
             initialDelaySeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 30
             periodSeconds: 10
             failureThreshold: 5
           volumeMounts:

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -764,7 +764,6 @@ spec:
                   - nsx-networking
               topologyKey: "kubernetes.io/hostname"
 
-      priorityClassName: system-cluster-critical
       containers:
         - name: nsx-ncp
           # Docker image for NCP
@@ -794,9 +793,9 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - check_pod_liveness nsx-ncp 5
+                - check_pod_liveness nsx-ncp 30
             initialDelaySeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 30
             periodSeconds: 10
             failureThreshold: 5
           volumeMounts:

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -551,7 +551,6 @@ spec:
                   - nsx-networking
               topologyKey: "kubernetes.io/hostname"
 
-      priorityClassName: system-cluster-critical
       containers:
         - name: nsx-ncp
           # Docker image for NCP
@@ -576,9 +575,9 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - check_pod_liveness nsx-ncp 5
+                - check_pod_liveness nsx-ncp 30
             initialDelaySeconds: 5
-            timeoutSeconds: 5
+            timeoutSeconds: 30
             periodSeconds: 10
             failureThreshold: 5
           volumeMounts:


### PR DESCRIPTION
Remove priorityClass for NCP
ncrease nsx-ncp pod liveness probe timeout to 30 seconds