### PR TITLE
Sync manifest and configmap change of NCP 4.1.2

### DIFF
--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -83,6 +83,7 @@ data:
     #enable_sha = True
 
 
+
     [ha]
 
 

--- a/deploy/openshift4/configmap.yaml
+++ b/deploy/openshift4/configmap.yaml
@@ -83,6 +83,7 @@ data:
     #enable_sha = True
 
 
+
     [ha]
 
 

--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -443,157 +443,6 @@ subjects:
 
 
 
-
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: nsx-node-agent-psp
-spec:
-  hostIPC: false
-  hostNetwork: true
-  hostPID: true
-  privileged: true
-  allowedCapabilities:
-  - SYS_ADMIN
-  - NET_ADMIN
-  - SYS_PTRACE
-  - DAC_READ_SEARCH
-  - SYS_NICE
-  - SYS_MODULE
-  - AUDIT_WRITE
-  - NET_RAW
-  defaultAddCapabilities: null
-  fsGroup:
-   rule: RunAsAny
-  readOnlyRootFilesystem: false
-  requiredDropCapabilities:
-  - KILL
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-    seLinuxOptions:
-      type: spc_t
-      level: s0:c0.c1023
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
-  - hostPath
-
----
-
-kind: ClusterRole
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nsx-node-agent-psp-cluster-role
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - nsx-node-agent-psp
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-
----
-
-kind: ClusterRoleBinding
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nsx-node-agent-psp-cluster-role-binding
-subjects:
-- kind: ServiceAccount
-  name: nsx-node-agent-svc-account
-  namespace: nsx-system
-roleRef:
-  kind: ClusterRole
-  name: nsx-node-agent-psp-cluster-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: ncp-psp
-spec:
-  hostNetwork: true
-  hostIPC: false
-  hostPID: false
-  privileged: false
-  allowedCapabilities:
-  - AUDIT_WRITE
-  defaultAddCapabilities: null
-  requiredDropCapabilities:
-  - KILL
-  runAsUser:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: MustRunAs
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: MustRunAs
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-
----
-
-kind: ClusterRole
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: ncp-psp-cluster-role
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - ncp-psp
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-
----
-
-kind: ClusterRoleBinding
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: ncp-psp-cluster-role-binding
-subjects:
-- kind: ServiceAccount
-  name: ncp-svc-account
-  namespace: nsx-system
-roleRef:
-  kind: ClusterRole
-  name: ncp-psp-cluster-role
-  apiGroup: rbac.authorization.k8s.io
-
 ---
 # Create Role for NCP to run exec on pods
 kind: Role
@@ -676,6 +525,9 @@ data:
 # must be specified.
 # This yaml file is part of NCP  release.
 
+
+
+
 # ConfigMap for ncp.ini
 apiVersion: v1
 kind: ConfigMap
@@ -692,6 +544,7 @@ data:
 
 
 ---
+
 
 apiVersion: apps/v1
 kind: Deployment
@@ -808,7 +661,9 @@ spec:
 
 
 
+
       volumes:
+
 
 
         - name: host-var-log-ujo

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -443,157 +443,6 @@ subjects:
 
 
 
-
----
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: nsx-node-agent-psp
-spec:
-  hostIPC: false
-  hostNetwork: true
-  hostPID: true
-  privileged: true
-  allowedCapabilities:
-  - SYS_ADMIN
-  - NET_ADMIN
-  - SYS_PTRACE
-  - DAC_READ_SEARCH
-  - SYS_NICE
-  - SYS_MODULE
-  - AUDIT_WRITE
-  - NET_RAW
-  defaultAddCapabilities: null
-  fsGroup:
-   rule: RunAsAny
-  readOnlyRootFilesystem: false
-  requiredDropCapabilities:
-  - KILL
-  runAsUser:
-    rule: RunAsAny
-  seLinux:
-    rule: RunAsAny
-    seLinuxOptions:
-      type: spc_t
-      level: s0:c0.c1023
-  supplementalGroups:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
-  - hostPath
-
----
-
-kind: ClusterRole
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nsx-node-agent-psp-cluster-role
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - nsx-node-agent-psp
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-
----
-
-kind: ClusterRoleBinding
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: nsx-node-agent-psp-cluster-role-binding
-subjects:
-- kind: ServiceAccount
-  name: nsx-node-agent-svc-account
-  namespace: nsx-system
-roleRef:
-  kind: ClusterRole
-  name: nsx-node-agent-psp-cluster-role
-  apiGroup: rbac.authorization.k8s.io
-
----
-
-apiVersion: policy/v1beta1
-kind: PodSecurityPolicy
-metadata:
-  name: ncp-psp
-spec:
-  hostNetwork: true
-  hostIPC: false
-  hostPID: false
-  privileged: false
-  allowedCapabilities:
-  - AUDIT_WRITE
-  defaultAddCapabilities: null
-  requiredDropCapabilities:
-  - KILL
-  runAsUser:
-    rule: RunAsAny
-  volumes:
-  - configMap
-  - downwardAPI
-  - emptyDir
-  - persistentVolumeClaim
-  - projected
-  - secret
-  seLinux:
-    rule: RunAsAny
-  supplementalGroups:
-    rule: MustRunAs
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  fsGroup:
-    rule: MustRunAs
-    ranges:
-      # Forbid adding the root group.
-      - min: 1
-        max: 65535
-  readOnlyRootFilesystem: false
-
----
-
-kind: ClusterRole
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: ncp-psp-cluster-role
-rules:
-- apiGroups:
-  - policy
-  resourceNames:
-  - ncp-psp
-  resources:
-  - podsecuritypolicies
-  verbs:
-  - use
-
----
-
-kind: ClusterRoleBinding
-# Set the apiVersion to rbac.authorization.k8s.io/v1beta1 when k8s < v1.8
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: ncp-psp-cluster-role-binding
-subjects:
-- kind: ServiceAccount
-  name: ncp-svc-account
-  namespace: nsx-system
-roleRef:
-  kind: ClusterRole
-  name: ncp-psp-cluster-role
-  apiGroup: rbac.authorization.k8s.io
-
 ---
 # Create Role for NCP to run exec on pods
 kind: Role
@@ -676,6 +525,9 @@ data:
 # must be specified.
 # This yaml file is part of NCP  release.
 
+
+
+
 # ConfigMap for ncp.ini
 apiVersion: v1
 kind: ConfigMap
@@ -692,6 +544,7 @@ data:
 
 
 ---
+
 
 apiVersion: apps/v1
 kind: Deployment
@@ -808,7 +661,9 @@ spec:
 
 
 
+
       volumes:
+
 
 
         - name: host-var-log-ujo

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -384,7 +384,6 @@ subjects:
 
 
 
-
 ---
 # Create Role for NCP to run exec on pods
 kind: Role
@@ -463,6 +462,9 @@ data:
 # must be specified.
 # This yaml file is part of NCP  release.
 
+
+
+
 # ConfigMap for ncp.ini
 apiVersion: v1
 kind: ConfigMap
@@ -479,6 +481,7 @@ data:
 
 
 ---
+
 
 apiVersion: apps/v1
 kind: Deployment
@@ -590,7 +593,9 @@ spec:
 
 
 
+
       volumes:
+
 
 
         - name: host-var-log-ujo
@@ -780,9 +785,6 @@ spec:
             mountPath: /usr/sbin/modinfo
             readOnly: true
 
-          # This lib mountpoint is for "modinfo" to work in CoreOS
-          - name: host-libcrypto
-            mountPath: /usr/lib64/libcrypto.so.1.1
           # Mount multus config dir for copying primary CNI config
           - mountPath: /host/var/run/multus
             name: host-multus
@@ -884,10 +886,6 @@ spec:
           hostPath:
             path: /usr/sbin/modinfo
 
-        # This lib mountpoint is for "modinfo" to work in CoreOS
-        - name: host-libcrypto
-          hostPath:
-            path: /usr/lib64/libcrypto.so.1.1
         - name: host-multus
           hostPath:
             path: /var/run/multus


### PR DESCRIPTION
Removing PodSecurityPolicy(PSP) since K8s 1.25 no longer doesn't support PSP

Removing volMount /usr/lib64/libcrypto.so.1.1 in bootstrap pod for OCP4 to support OCP 4.13