### PR TITLE
Install Golang 1.19 for docker build and release build(238)

### DIFF
--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -9,6 +9,10 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
+    - name: Set up Go 1.19
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.19
     - uses: actions/checkout@v2
     - name: Build Operator image and push to registry
       env:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,4 @@
+FROM golang:1.19.10 as golang-build
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 LABEL name="nsx-container-plugin-operator"


### PR DESCRIPTION
Starting with Go 1.21, the runtime system needs to have a version of glibc "compatible" with the version available at build time. The ubi8 image comes with a very old version of glibc compared to the golang builder. so, the NCP Operator binaries will fail to run and hit GLIBC issue.

To fix this issue, we need to install Golang manually in ubi8 image when making docker build. Moreover, we use Golang 1.19 for Github workflow build action. To align this workflow, we install Golang 1.19 for Github workflow build tag action and Docker image build.

Fix issue:https://github.com/vmware/nsx-container-plugin-operator/issues/237
CP from https://github.com/vmware/nsx-container-plugin-operator/pull/238