### PR TITLE
Upgrade golang to 1.21.5 and disable CGO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,10 +12,10 @@ jobs:
   build-image:
     runs-on: [ubuntu-latest]
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21.5
           cache: false
       - name: Check-out code
         uses: actions/checkout@v4

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: [ubuntu-latest]
     steps:
-    - name: Set up Go 1.19
+    - name: Set up Go 1.21
       uses: actions/setup-go@v4
       with:
-        go-version: 1.19
+        go-version: 1.21.5
         cache: false
     - uses: actions/checkout@v4
     - name: Build Operator image and push to registry

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     name: Unit test
     runs-on: [ubuntu-latest]
     steps:
-      - name: Set up Go 1.19
+      - name: Set up Go 1.21
         uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.21.5
           cache: false
       - name: Check-out code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ OPERATOR_IMG_NAME = vmware/nsx-container-plugin-operator
 
 .PHONY: build
 build:
-	GOOS=linux $(GO) build -o $(BINDIR)/$(OPERATOR_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./cmd/manager
+	CGO_ENABLED=0 GOOS=linux $(GO) build -o $(BINDIR)/$(OPERATOR_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./cmd/manager
 	docker build -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION)
 	docker tag $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION) $(OPERATOR_IMG_NAME)
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:1.19.10 as golang-build
+FROM golang:1.21.5 as golang-build
 FROM registry.access.redhat.com/ubi8/ubi:latest
 
 LABEL name="nsx-container-plugin-operator"
-LABEL maintainer="NSX Containers Team <nsx-container-dev@vmware.com>"
+LABEL maintainer="NSX Containers Team <container-dev.pdl@broadcom.com>"
 LABEL summary="A cluster operator to deploy nsx-ncp CNI plugin"
 LABEL version="0.0.3"
 LABEL release="1"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/nsx-container-plugin-operator
 
-go 1.19
+go 1.21.5
 
 require (
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -943,6 +943,7 @@ golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1115,6 +1116,7 @@ golang.org/x/tools v0.0.0-20200327195553-82bb89366a1e/go.mod h1:Sl4aGygMT6LrqrWc
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
+golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -373,7 +373,7 @@ func TestNeedApplyChange(t *testing.T) {
 	(*preData)[operatortypes.ConfigMapDataKey], _ = iniWriteToString(preCfg)
 	needChange, err = NeedApplyChange(currConfigMap, prevConfigMap)
 	assert.True(t, needChange.ncp)
-	assert.True(t, needChange.agent)
+	assert.False(t, needChange.agent)
 	assert.False(t, needChange.bootstrap)
 	assert.Nil(t, err)
 


### PR DESCRIPTION
This patch is to
1.Upgrade goalng version from 1.19.10 to 1.21.5.
2.Disable CGO for golang compilation to fix UBI8 with libc compatibility issue with golang version >=1.20.
3.Fix an error of config unit test.