### PR TITLE
Set enable_ovs_mcast_snooping as false by default

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -110,8 +110,9 @@ func (adaptor *ConfigMapOc) FillDefaults(configmap *corev1.ConfigMap, spec *conf
 	// For Openshift add a 3-seconds agent delay by default
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "waiting_before_cni_response", "3", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "mtu", strconv.Itoa(operatortypes.DefaultMTU), false))
-	// For Openshift force enable_ovs_mcast_snooping as True by default for IPI and UPI installation
-	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "enable_ovs_mcast_snooping", "true", false))
+	// For Openshift force enable_ovs_mcast_snooping as False by default for IPI and UPI installation
+        // keepalived is configured with unicast by default from OC 4.11
+	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "enable_ovs_mcast_snooping", "false", false))
 	appendErrorIfNotNil(&errs, fillClusterNetwork(spec, cfg))
 
 	// Write config back to ConfigMap data

--- a/pkg/controller/configmap/config_test.go
+++ b/pkg/controller/configmap/config_test.go
@@ -89,7 +89,7 @@ func TestFillDefaults(t *testing.T) {
 	assert.Equal(t, "10.0.0.0/24", cfg.Section("nsx_v3").Key("container_ip_blocks").Value())
 	assert.Equal(t, "3", cfg.Section("nsx_node_agent").Key("waiting_before_cni_response").Value())
 	assert.Equal(t, "1500", cfg.Section("nsx_node_agent").Key("mtu").Value())
-	assert.Equal(t, "true", cfg.Section("nsx_node_agent").Key("enable_ovs_mcast_snooping").Value())
+	assert.Equal(t, "false", cfg.Section("nsx_node_agent").Key("enable_ovs_mcast_snooping").Value())
 
 	mockConfigMap := createMockConfigMap()
 	data = &mockConfigMap.Data


### PR DESCRIPTION
keepalived is configured with unicast by default from OC 4.11