### PR TITLE
Update description of conf opt enable_mixed_expression_groups

### DIFF
--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -611,14 +611,17 @@ data:
     # Choices: MATCH_EXTERNAL_ADDRESS MATCH_INTERNAL_ADDRESS BYPASS
     #natfirewallmatch = MATCH_INTERNAL_ADDRESS
 
-    # Boolean; set to True to leverage NSX groups with mixed expressions, False
-    # to keep them disabled. Defaults to False. With mixed expressions enabled,
+    # Deprecated; Boolean; set to True to leverage NSX groups with mixed
+    # expressions, False to keep them disabled. Applicable only if NSX
+    # version is less than 4.2.0. Defaults to False. Enforced to True
+    # if NSX version is 4.2.0 or higher. With mixed expressions enabled,
     # NCP will create NSX DFW rules for K8S network policies with
-    # multiselectors such that all pods in an arbitrary number of namespaces
-    # are subjected to DFW; without this feature enabled, the NSX rules for
-    # network policies with multiselectors can select pods in at most 5
-    # namespaces. This should be disabled if significant delays in NSX
-    # effective group membership evaluation are observed
+    # multiselectors such that all pods in an arbitrary number of
+    # namespaces are subjected to DFW; without this feature
+    # enabled, the NSX rules for network policies with multiselectors
+    # can select pods in at most 5 namespaces. This should be disabled
+    # if significant delays in NSX effective group membership evaluation
+    # are observed
     #enable_mixed_expression_groups = False
 
 

--- a/deploy/openshift4/configmap.yaml
+++ b/deploy/openshift4/configmap.yaml
@@ -605,14 +605,17 @@ data:
     # Choices: MATCH_EXTERNAL_ADDRESS MATCH_INTERNAL_ADDRESS BYPASS
     #natfirewallmatch = MATCH_INTERNAL_ADDRESS
 
-    # Boolean; set to True to leverage NSX groups with mixed expressions, False
-    # to keep them disabled. Defaults to False. With mixed expressions enabled,
+    # Deprecated; Boolean; set to True to leverage NSX groups with mixed
+    # expressions, False to keep them disabled. Applicable only if NSX
+    # version is less than 4.2.0. Defaults to False. Enforced to True
+    # if NSX version is 4.2.0 or higher. With mixed expressions enabled,
     # NCP will create NSX DFW rules for K8S network policies with
-    # multiselectors such that all pods in an arbitrary number of namespaces
-    # are subjected to DFW; without this feature enabled, the NSX rules for
-    # network policies with multiselectors can select pods in at most 5
-    # namespaces. This should be disabled if significant delays in NSX
-    # effective group membership evaluation are observed
+    # multiselectors such that all pods in an arbitrary number of
+    # namespaces are subjected to DFW; without this feature
+    # enabled, the NSX rules for network policies with multiselectors
+    # can select pods in at most 5 namespaces. This should be disabled
+    # if significant delays in NSX effective group membership evaluation
+    # are observed
     #enable_mixed_expression_groups = False
 
 


### PR DESCRIPTION
Adds that enable_mixed_expression_groups is
1. applicable only if NSX version < 4.2.0
2. always set to True if NSX version >= 4.2.0