### PR TITLE
Allow NcpReplicas to be set to 0

### DIFF
--- a/bundle/kubernetes/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/bundle/kubernetes/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -41,7 +41,7 @@ spec:
                 description: the replica numbers of nsx-ncp deployment
                 type: integer
                 format: int32
-                minimum: 1
+                minimum: 0
               addNodeTag:
                 description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
                   Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'

--- a/bundle/openshift4/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/bundle/openshift4/manifests/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -41,7 +41,7 @@ spec:
                 description: the replica numbers of nsx-ncp deployment
                 type: integer
                 format: int32
-                minimum: 1
+                minimum: 0 
               addNodeTag:
                 description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
                   Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'

--- a/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/kubernetes/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -41,7 +41,7 @@ spec:
                 description: the replica numbers of nsx-ncp deployment
                 type: integer
                 format: int32
-                minimum: 1
+                minimum: 0
               addNodeTag:
                 description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
                   Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'

--- a/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
+++ b/deploy/openshift4/operator.nsx.vmware.com_ncpinstalls_crd.yaml
@@ -41,7 +41,7 @@ spec:
                 description: the replica numbers of nsx-ncp deployment
                 type: integer
                 format: int32
-                minimum: 1
+                minimum: 0
               addNodeTag:
                 description: 'Tag node logical switch port with node name and cluster when set to true, skip tagging when set to false.
                   Note that if one node has multiple attached VirtualNetworkInterfaces, this function is not supported and should be set to false.'

--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -111,7 +111,7 @@ func (adaptor *ConfigMapOc) FillDefaults(configmap *corev1.ConfigMap, spec *conf
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "waiting_before_cni_response", "3", false))
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "mtu", strconv.Itoa(operatortypes.DefaultMTU), false))
 	// For Openshift force enable_ovs_mcast_snooping as False by default for IPI and UPI installation
-        // keepalived is configured with unicast by default from OC 4.11
+	// keepalived is configured with unicast by default from OC 4.11
 	appendErrorIfNotNil(&errs, fillDefault(cfg, "nsx_node_agent", "enable_ovs_mcast_snooping", "false", false))
 	appendErrorIfNotNil(&errs, fillClusterNetwork(spec, cfg))
 
@@ -417,7 +417,7 @@ func Render(configmap *corev1.ConfigMap, ncpReplicas *int32, ncpNodeSelector *ma
 		}
 	}
 
-	if !haEnabled && *ncpReplicas != 1 {
+	if !haEnabled && *ncpReplicas > 1 {
 		log.Info(fmt.Sprintf("Set nsx-ncp deployment replicas to 1 instead of %d as HA is deactivated",
 			*ncpReplicas))
 		*ncpReplicas = 1

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -237,9 +237,8 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 	}
 	ncpReplicas := ncpInstallCrd.Spec.NcpReplicas
 	if ncpReplicas == 0 {
-		log.Info(fmt.Sprintf("Set NcpReplicas to %d as it is not set in ncp-install CRD",
-			operatortypes.NcpDefaultReplicas))
-		ncpReplicas = int32(operatortypes.NcpDefaultReplicas)
+		// still log the event for troubleshooting purposes
+		log.Info("NcpReplicas was set to 0 and NCP won't be operational!")
 	}
 
 	addNodeTag := ncpInstallCrd.Spec.AddNodeTag


### PR DESCRIPTION
There are some scenarios were NCP must be temporarily shut down. This can be done by setting the number of replicas to 0, but the operator currently prevents that.