### PR TITLE
Update NCP ClusterRole to access ingresscontrollers

### DIFF
--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -224,6 +224,16 @@ rules:
 
 
 
+
+ - apiGroups:
+   - operator.openshift.io
+   resources:
+   - ingresscontrollers
+   verbs:
+   - list
+
+
+
 ---
 
 # Create ClusterRole for NCP to edit resources


### PR DESCRIPTION
ncp-openshift4.yaml is outdated and it needs to be update in order to access ingresscontrollers from api group operator.openshift.io for NCP