### PR TITLE
build: move to two-stage Docker build, upgrade to Go 1.26.4

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**
+
+!go.mod
+!go.sum
+!cmd/**
+!pkg/**
+!version/**
+!manifest/**
+!build/bin/entrypoint
+!build/bin/user_setup
+!LICENSE

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.26
         uses: actions/setup-go@v4
         with:
-          go-version: 1.26.2
+          go-version: 1.26.4
           cache: false
       - name: Check-out code
         uses: actions/checkout@v4

--- a/.github/workflows/build_tag.yml
+++ b/.github/workflows/build_tag.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go 1.26
       uses: actions/setup-go@v4
       with:
-        go-version: 1.26.2
+        go-version: 1.26.4
         cache: false
     - uses: actions/checkout@v4
     - name: Build Operator image and push to registry

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go 1.26
         uses: actions/setup-go@v4
         with:
-          go-version: 1.26.2
+          go-version: 1.26.4
           cache: false
 
       - name: Log in to Docker Hub

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go 1.26
         uses: actions/setup-go@v4
         with:
-          go-version: 1.26.2
+          go-version: 1.26.4
           cache: false
       - name: Check-out code
         uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,7 @@ OPERATOR_IMG_NAME = vmware/nsx-container-plugin-operator
 
 .PHONY: build
 build:
-	CGO_ENABLED=0 GOOS=linux $(GO) build -o $(BINDIR)/$(OPERATOR_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./cmd/manager
-	docker build -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION)
+	docker build --build-arg LDFLAGS="$(LDFLAGS)" -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION)
 	docker tag $(OPERATOR_IMG_NAME):$(DOCKER_IMG_VERSION) $(OPERATOR_IMG_NAME)
 
 .PHONY: bin
@@ -61,13 +60,11 @@ kind-stop:
 
 .PHONY: build-test-images
 build-test-images:
-	CGO_ENABLED=0 GOOS=linux $(GO) build -o $(BINDIR)/$(OPERATOR_NAME) $(GOFLAGS) -ldflags '$(LDFLAGS)' ./cmd/manager
-	# Temporarily strip AppArmor annotation for E2E testing on Kind
-	python3 -c "import sys; f = 'manifest/kubernetes/ubuntu/ncp-ubuntu.yaml'; c = open(f).read().replace('      annotations:\n        container.apparmor.security.beta.kubernetes.io/nsx-node-agent: localhost/node-agent-apparmor', '      annotations: {}'); open(f, 'w').write(c)"
-	docker build -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):latest; \
-	status=$$?; \
-	git checkout manifest/kubernetes/ubuntu/ncp-ubuntu.yaml; \
-	exit $$status
+	@bash -c 'set -e; \
+	  MANIFEST=manifest/kubernetes/ubuntu/ncp-ubuntu.yaml; \
+	  trap "git checkout $$MANIFEST" EXIT; \
+	  python3 -c "import sys; f=\"$$MANIFEST\"; c=open(f).read().replace(\"      annotations:\n        container.apparmor.security.beta.kubernetes.io/nsx-node-agent: localhost/node-agent-apparmor\", \"      annotations: {}\"); open(f,\"w\").write(c)"; \
+	  docker build --build-arg LDFLAGS="$(LDFLAGS)" -f build/Dockerfile . -t $(OPERATOR_IMG_NAME):latest'
 	docker build -f build/fake-ncp/Dockerfile build/fake-ncp -t vmware/fake-ncp:v1
 	docker tag vmware/fake-ncp:v1 vmware/fake-ncp:v2-patched
 	docker build -f cmd/nsx-mock/Dockerfile . -t vmware/nsx-mock:latest
@@ -97,7 +94,7 @@ deploy-e2e:
 
 .PHONY: test-e2e-local
 test-e2e-local:
-	$(GO) test -v -count=1 -timeout 15m ./test/e2e/...
+	$(GO) test -v -count=1 -timeout 15m -ldflags '$(LDFLAGS)' ./test/e2e/...
 
 .PHONY: test-e2e
 test-e2e: kind-start build-test-images load-images deploy-e2e test-e2e-local kind-stop

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,5 +1,15 @@
-FROM golang:1.26.2 as golang-build
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM golang:1.26.4 AS golang-build
+
+WORKDIR /workspace
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+ARG LDFLAGS=""
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "${LDFLAGS}" -o build/bin/nsx-ncp-operator ./cmd/manager
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 LABEL name="nsx-container-plugin-operator"
 LABEL maintainer="NSX Containers Team <container-dev.pdl@broadcom.com>"
@@ -15,11 +25,11 @@ ENV OPERATOR=/usr/local/bin/nsx-ncp-operator \
     USER_UID=1001 \
     USER_NAME=nsx-ncp-operator
 
-COPY build/bin /usr/local/bin
+COPY build/bin/entrypoint /usr/local/bin/entrypoint
+COPY build/bin/user_setup /usr/local/bin/user_setup
+COPY --from=golang-build /workspace/build/bin/nsx-ncp-operator /usr/local/bin/nsx-ncp-operator
 COPY manifest /manifest
-RUN  rpm -e --nodeps curl-minimal || true && \
-     rpm -e --nodeps libcurl-minimal || true  && \
-     /usr/local/bin/user_setup
+RUN  /usr/local/bin/user_setup
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]
 

--- a/cmd/nsx-mock/Dockerfile
+++ b/cmd/nsx-mock/Dockerfile
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Build stage
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 WORKDIR /workspace
 
 # Copy dependency files

--- a/deploy/e2e/operator.yaml
+++ b/deploy/e2e/operator.yaml
@@ -43,7 +43,7 @@ spec:
       containers:
         - name: nsx-ncp-operator
           image: vmware/nsx-container-plugin-operator:latest
-          command: ["/bin/bash", "-c", "nsx-ncp-operator --metrics-server-bind-address=:8181"]
+          command: ["/bin/bash", "-c", "nsx-ncp-operator --zap-time-encoding=iso8601 --metrics-server-bind-address=:8181"]
           volumeMounts:
           - mountPath: /host/etc/os-release
             name: host-os-release

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vmware/nsx-container-plugin-operator
 
-go 1.26.2
+go 1.26.4
 
 require (
 	dario.cat/mergo v1.0.2

--- a/test/e2e/operator_test.go
+++ b/test/e2e/operator_test.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/vmware/nsx-container-plugin-operator/pkg/apis"
 	operatorv1 "github.com/vmware/nsx-container-plugin-operator/pkg/apis/operator/v1"
+	"github.com/vmware/nsx-container-plugin-operator/version"
 )
 
 const (
@@ -93,7 +94,6 @@ func TestOperatorE2E(t *testing.T) {
 	if err := rbacv1.AddToScheme(scheme); err != nil {
 		t.Fatalf("Failed to add rbac APIs to scheme: %v", err)
 	}
-
 	k8sClient, err := client.New(config, client.Options{Scheme: scheme})
 	if err != nil {
 		t.Fatalf("Failed to create controller-runtime client: %v", err)
@@ -121,6 +121,32 @@ func TestOperatorE2E(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Operator deployment failed to become ready: %v", err)
 		}
+	})
+
+	// --- Version Reporting ---
+	t.Run("Operator Reports Correct Version", func(t *testing.T) {
+		pods, err := clientset.CoreV1().Pods(operatorNamespace).List(ctx, metav1.ListOptions{
+			LabelSelector: "name=nsx-ncp-operator",
+		})
+		if err != nil || len(pods.Items) == 0 {
+			t.Fatalf("Failed to list operator pods: %v", err)
+		}
+
+		expectedLine := fmt.Sprintf("Operator Version: %s", version.Version)
+		var logBytes []byte
+		err = wait.PollImmediate(2*time.Second, 30*time.Second, func() (bool, error) {
+			logBytes, err = clientset.CoreV1().Pods(operatorNamespace).
+				GetLogs(pods.Items[0].Name, &corev1.PodLogOptions{}).
+				DoRaw(ctx)
+			if err != nil {
+				return false, err
+			}
+			return strings.Contains(string(logBytes), expectedLine), nil
+		})
+		if err != nil {
+			t.Fatalf("Operator pod logs do not contain %q — version stamp is missing or wrong.\nLogs:\n%s", expectedLine, string(logBytes))
+		}
+		t.Logf("Operator pod logs confirm version %s", version.Version)
 	})
 
 	// Setup: Patch existing nodes with vsphere ProviderIDs so the node controller can reconcile them

--- a/version/version.go
+++ b/version/version.go
@@ -3,6 +3,8 @@
 
 package version
 
-const (
-	Version = "0.0.3"
+var (
+	Version      = "0.0.3"
+	GitSHA       = "unknown"
+	GitTreeState = "unknown"
 )

--- a/versioning.mk
+++ b/versioning.mk
@@ -25,9 +25,9 @@ else
         DOCKER_IMG_VERSION := $(VERSION)
 endif
 
-VERSION_LDFLAGS = -X github.com/vmware/nsx-container-plugin-operator/pkg/version.Version=$(VERSION)
-VERSION_LDFLAGS += -X github.com/vmware/nsx-container-plugin-operator/pkg/version.GitSHA=$(GIT_SHA)
-VERSION_LDFLAGS += -X github.com/vmware/nsx-container-plugin-operator/pkg/version.GitTreeState=$(GIT_TREE_STATE)
+VERSION_LDFLAGS = -X github.com/vmware/nsx-container-plugin-operator/version.Version=$(VERSION)
+VERSION_LDFLAGS += -X github.com/vmware/nsx-container-plugin-operator/version.GitSHA=$(GIT_SHA)
+VERSION_LDFLAGS += -X github.com/vmware/nsx-container-plugin-operator/version.GitTreeState=$(GIT_TREE_STATE)
 
 
 version-info:


### PR DESCRIPTION
- Activate the golang-build stage in Dockerfile to compile the operator binary inside Docker (CGO_ENABLED=0)
- Upgrade base image from UBI8 to UBI9 minimal
- Upgrade Go toolchain from 1.26.2 to 1.26.4 (CVE fixes)
- Remove pre-build step from Makefile: binary is now built entirely within the Docker multi-stage build