### PR TITLE
Fix network status update failure with Server-Side Apply

### DIFF
--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -553,6 +553,9 @@ func updateNetworkStatus(ctx context.Context, networkConfig *configv1.Network, c
 	}
 
 	if data != nil {
+		data.SetManagedFields(nil)
+		data.SetResourceVersion("")
+		data.SetUID("")
 		if err := r.client.Apply(ctx, client.ApplyConfigurationFromUnstructured(data), client.FieldOwner("nsx-ncp-operator"), client.ForceOwnership); err != nil {
 			log.Error(err, fmt.Sprintf("Could not apply (%s) %s/%s", data.GroupVersionKind(),
 				data.GetNamespace(), data.GetName()))


### PR DESCRIPTION
## Summary
- Clear server-managed metadata fields (`managedFields`, `resourceVersion`, and `uid`) from the unstructured Network object before applying it.
- This prevents the Kubernetes API server from rejecting the Server-Side Apply request with a "metadata.managedFields must be nil" error.

## Test plan
- Verified that the codebase compiles and all unit tests pass successfully.

Made with [Cursor](https://cursor.com)