### PR TITLE
Fix nsx-ncp liveness probe broken by nsx-ujo change 823215

### DIFF
--- a/manifest/kubernetes/rhel/ncp-rhel.yaml
+++ b/manifest/kubernetes/rhel/ncp-rhel.yaml
@@ -649,12 +649,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          # liveness.DEFAULT_LIVENESS_TIMEOUT bounds the in-process deep check
+          # below timeoutSeconds, so a wedged check surfaces as a probe
+          # failure rather than a kubelet client timeout.
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - check_pod_liveness nsx-ncp 30
+            httpGet:
+              path: /healthz
+              port: 8086
+              host: 127.0.0.1
+              scheme: HTTP
             initialDelaySeconds: 5
             timeoutSeconds: 30
             periodSeconds: 10

--- a/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
+++ b/manifest/kubernetes/ubuntu/ncp-ubuntu.yaml
@@ -649,12 +649,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          # liveness.DEFAULT_LIVENESS_TIMEOUT bounds the in-process deep check
+          # below timeoutSeconds, so a wedged check surfaces as a probe
+          # failure rather than a kubelet client timeout.
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - check_pod_liveness nsx-ncp 30
+            httpGet:
+              path: /healthz
+              port: 8086
+              host: 127.0.0.1
+              scheme: HTTP
             initialDelaySeconds: 5
             timeoutSeconds: 30
             periodSeconds: 10

--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -587,12 +587,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          # liveness.DEFAULT_LIVENESS_TIMEOUT bounds the in-process deep check
+          # below timeoutSeconds, so a wedged check surfaces as a probe
+          # failure rather than a kubelet client timeout.
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - -c
-                - check_pod_liveness nsx-ncp 30
+            httpGet:
+              path: /healthz
+              port: 8086
+              host: 127.0.0.1
+              scheme: HTTP
             initialDelaySeconds: 5
             timeoutSeconds: 30
             periodSeconds: 10


### PR DESCRIPTION
## Summary
- nsx-ujo change 823215 replaced NCP's exec-based liveness probe with an in-process httpGet probe on `:8086/healthz`, and removed the `"nsx-ncp"` handler from `check_pod_liveness`'s dispatch table entirely.
- This operator's static manifests (`ncp-openshift4.yaml`, `ncp-rhel.yaml`, `ncp-ubuntu.yaml`) still invoke the removed exec probe (`check_pod_liveness nsx-ncp 30`). Since `"nsx-ncp"` is no longer a recognized target, the script falls through to `null_handler`, which always reports failure -- so the liveness probe now always fails and kubelet restart-loops the NCP pod on every platform this operator manages (OpenShift, RHEL, Ubuntu Kubernetes).
- Switches all three manifests to the same httpGet probe nsx-ujo now ships: `containerPort: 8086`, `host: 127.0.0.1` (all three pods already run `hostNetwork: true`, so kubelet and NCP share the host network namespace and loopback is reachable), preserving the existing `initialDelaySeconds`/`timeoutSeconds`/`periodSeconds`/`failureThreshold`.
