### PR TITLE
[OCP] Fix the symlink mount issue in nsx-ncp-bootstrap DaemonSet

### DIFF
--- a/manifest/openshift4/coreos/ncp-openshift4.yaml
+++ b/manifest/openshift4/coreos/ncp-openshift4.yaml
@@ -754,7 +754,7 @@ spec:
           # mounts to which NSX-CNI are copied END
           # mount host's OS info to identify host OS
           - name: host-os-release
-            mountPath: /host/etc/os-release
+            mountPath: /host/usr/lib/os-release
 
 
 {{if .UseNsxOvsKmod}}
@@ -795,7 +795,7 @@ spec:
             readOnly: true
 
           # Mount multus config dir for copying primary CNI config
-          - mountPath: /host/var/run/multus
+          - mountPath: /host/run/multus
             name: host-multus
           - mountPath: /host/proc/sys/net
             name: host-proc-sys-net


### PR DESCRIPTION
## Summary
- `nsx-ncp-bootstrap`'s init container mounted `host-os-release` (`/etc/os-release`) nested under the already-mounted `host-etc` (`/host/etc`). RHCOS's `/etc/os-release` is a symlink to `../usr/lib/os-release`, and newer crun/CRI-O symlink-mount hardening on OpenShift rejects creating this nested mount point, failing pods with `container create failed: openat2 \`host/etc/os-release\`: No such file or directory`.
- Fix: mount the host file at its real (non-symlink) location, `/host/usr/lib/os-release`, which isn't nested under any other mount in this container. The pre-existing symlink at `/host/etc/os-release` (brought in by the `host-etc` directory mount) then resolves correctly against it, so `init_k8s_node` (which reads `/host/etc/os-release`) keeps working.
- Also fixes an adjacent `host-multus` mountPath (`/host/var/run/multus` -> `/host/run/multus`) to match its hostPath source (`/var/run/multus`).

