### PR TITLE
[OCP] Fix os-release ID detection for OpenShift 4.19 (rhel vs rhcos)

### DIFF
--- a/pkg/controller/sharedinfo/shared_info.go
+++ b/pkg/controller/sharedinfo/shared_info.go
@@ -45,7 +45,9 @@ func getAdaptorName() (string, error) {
 		log.Error(err, fmt.Sprintf("Failed to load os-release from %s.", operatortypes.OsReleaseFile))
 		return "", err
 	}
-	if cfg.Section("").Key("ID").String() == "rhcos" {
+	// For OpenShift <= 4.18, the ID value is "rhcos"; for OpenShift 4.19, the ID value is "rhel".
+	// For OpenShift 4.18 and 4.19, the key OPENSHIFT_VERSION exists. Didn't check the other versions.
+	if cfg.Section("").Key("ID").String() == "rhcos" || cfg.Section("").HasKey("OPENSHIFT_VERSION") {
 		return "openshift4", nil
 	}
 	return "kubernetes", nil


### PR DESCRIPTION
## Summary

- Cherry-picks upstream commit fde8fb6 ("Fix the OCP 4.19 deploy issue caused by os-release content change (#284)"): starting with OpenShift 4.19, RHCOS's `/etc/os-release` reports `ID="rhel"` instead of `ID="rhcos"`. `getAdaptorName()` in `pkg/controller/sharedinfo/shared_info.go` only matched `ID=="rhcos"`, so on 4.19 it misdetects the cluster as plain Kubernetes instead of OpenShift. This skips OpenShift-only ConfigMap defaulting (e.g. `container_ip_blocks` derived from the cluster Network CRD), leading to:
  ```
  Reconciler error ... invalid configuration: ["failed to get key container_ip_blocks from section nsx_v3"]
  ```
- Fix: also treat the presence of `OPENSHIFT_VERSION` in `os-release` as OpenShift, which is present on both 4.18 (`ID=rhcos`) and 4.19 (`ID=rhel`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/controller/configmap/...`