### PR TITLE
Fix error while updating Network.config.openshift.io

### DIFF
--- a/pkg/controller/configmap/config.go
+++ b/pkg/controller/configmap/config.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -49,7 +50,8 @@ type Adaptor interface {
 	validateClusterNetwork(spec *configv1.NetworkSpec) []error
 	HasNetworkConfigChange(currConfig *configv1.Network, prevConfig *configv1.Network) bool
 	setControllerReference(r *ReconcileConfigMap, networkConfig *configv1.Network, obj metav1.Object) error
-	getNetworkConfig(r *ReconcileConfigMap) (*configv1.Network, error)
+	// This functions returns both the structured and the unstructured object
+	getNetworkConfig(r *ReconcileConfigMap) (*configv1.Network, map[string]interface{}, error)
 }
 
 type ConfigMap struct{}
@@ -247,14 +249,31 @@ func (adaptor *ConfigMapOc) setControllerReference(r *ReconcileConfigMap, networ
 	return err
 }
 
-func (adaptor *ConfigMapK8s) getNetworkConfig(r *ReconcileConfigMap) (*configv1.Network, error) {
-	return &configv1.Network{}, nil
+func (adaptor *ConfigMapK8s) getNetworkConfig(r *ReconcileConfigMap) (*configv1.Network, map[string]interface{}, error) {
+	return &configv1.Network{}, nil, nil
 }
 
-func (adaptor *ConfigMapOc) getNetworkConfig(r *ReconcileConfigMap) (*configv1.Network, error) {
+func (adaptor *ConfigMapOc) getNetworkConfig(r *ReconcileConfigMap) (*configv1.Network, map[string]interface{}, error) {
+	// Fetch as unstructured, rather than directly into the typed configv1.Network.
+	// We want to preserve the raw spec and reus as-is when updating the
+	// Network status later. The openshift API package we are using is too old and
+	// it lacks spec fields such as networkDiagnostics (added in OCP 4.16+).
+	existing := &unstructured.Unstructured{}
+	existing.SetGroupVersionKind(configv1.GroupVersion.WithKind("Network"))
+	if err := r.client.Get(context.TODO(), types.NamespacedName{Name: operatortypes.NetworkCRDName}, existing); err != nil {
+		return nil, nil, err
+	}
+	// create typed object from unstrucuted data
 	networkConfig := &configv1.Network{}
-	err := r.client.Get(context.TODO(), types.NamespacedName{Name: operatortypes.NetworkCRDName}, networkConfig)
-	return networkConfig, err
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(existing.Object, networkConfig); err != nil {
+		return nil, nil, err
+	}
+	// keep spec from unstructured so we can pass it later to Apply
+	rawSpec, _, err := unstructured.NestedMap(existing.Object, "spec")
+	if err != nil {
+		return nil, nil, err
+	}
+	return networkConfig, rawSpec, nil
 }
 
 func appendErrorIfNotNil(errs *[]error, err error) {

--- a/pkg/controller/configmap/configmap_controller.go
+++ b/pkg/controller/configmap/configmap_controller.go
@@ -279,7 +279,7 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 	}
 
 	// Get network CRD configuration
-	networkConfig, err := r.getNetworkConfig(r)
+	networkConfig, rawNetworkSpec, err := r.getNetworkConfig(r)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -446,7 +446,7 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 			if !ncpDeploymentChanged && !nsxNodeAgentDsChanged {
 				// Check if network config status must be updated
 				if networkConfigChanged {
-					err = updateNetworkStatus(networkConfig, instance, r)
+					err = updateNetworkStatus(networkConfig, rawNetworkSpec, instance, r)
 					if err != nil {
 						r.status.SetDegraded(statusmanager.ClusterConfig, "UpdateNetworkStatusError",
 							fmt.Sprintf("Failed to update network status: %v", err))
@@ -534,7 +534,7 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 
 	// Update network CRD status
 	if networkConfigChanged {
-		err = updateNetworkStatus(networkConfig, instance, r)
+		err = updateNetworkStatus(networkConfig, rawNetworkSpec, instance, r)
 		if err != nil {
 			r.status.SetDegraded(statusmanager.ClusterConfig, "UpdateNetworkStatusError",
 				fmt.Sprintf("Failed to update network status: %v", err))
@@ -547,7 +547,7 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 	return reconcile.Result{}, nil
 }
 
-func updateNetworkStatus(networkConfig *configv1.Network, configMap *corev1.ConfigMap, r *ReconcileConfigMap) error {
+func updateNetworkStatus(networkConfig *configv1.Network, rawNetworkSpec map[string]interface{}, configMap *corev1.ConfigMap, r *ReconcileConfigMap) error {
 	status := buildNetworkStatus(networkConfig, configMap)
 	// Render information
 	networkConfig.Status = status
@@ -561,10 +561,13 @@ func updateNetworkStatus(networkConfig *configv1.Network, configMap *corev1.Conf
 		data.SetManagedFields(nil)
 		data.SetResourceVersion("")
 		data.SetUID("")
-		// Remove 'spec' field from the apply configuration so that the operator
-		// only applies status/metadata changes, avoiding schema validation
-		// failures on uninitialized 'spec.networkDiagnostics' fields.
-		unstructured.RemoveNestedField(data.Object, "spec")
+		// Use unstructured to populate spec with the same data we retrieved earlier
+		// spec contains mandatory attributes such as NetworkDiagnostics which are not
+		// available in the version of the openshift Network API used in this version
+		// of the Operator
+		if rawNetworkSpec != nil {
+			unstructured.SetNestedMap(data.Object, rawNetworkSpec, "spec")
+		}
 		if err := apply.ApplyObject(context.TODO(), r.client, data); err != nil {
 			log.Error(err, fmt.Sprintf("Could not apply (%s) %s/%s", data.GroupVersionKind(),
 				data.GetNamespace(), data.GetName()))


### PR DESCRIPTION
To avoid issues with spec missing the NetworkDiagnostics field, the code is currently entirely removing the spec field. This requires the ability to do server-side patch, which is not available in this branch.

This change works around this issue by submitting the Network's spec exactly as we retrieved it from the API server, since the only thing we want to update is the Network's status.

To this aim, we have to fetch the unstructured Network object, because the openshift API client used in this branch has an older version of the Network object which does not include fields added in OCP 4.16 and above such as NetworkDiagnostics.